### PR TITLE
Testing an argo compatible output

### DIFF
--- a/monitoring-satellite/main-argo-test.jsonnet
+++ b/monitoring-satellite/main-argo-test.jsonnet
@@ -1,0 +1,79 @@
+local gitpod = import './components/gitpod/gitpod.libsonnet';
+
+local kp =
+  (import 'kube-prometheus/main.libsonnet') +
+  (import 'kube-prometheus/platforms/gke.libsonnet') +
+  (import 'kube-prometheus/addons/podsecuritypolicies.libsonnet') +
+  (import './addons/disable-grafana-auth.libsonnet') +
+  (import 'kube-prometheus/addons/strip-limits.libsonnet') +
+  (import './addons/gitpod-runbooks.libsonnet') +
+  (if std.extVar('remote_write_url') != '' then (import './addons/remote-write.libsonnet') else {}) +
+  (if std.extVar('slack_webhook_url_critical') != '' then (import './addons/slack-alerting.libsonnet') else {}) +
+  (if std.extVar('dns_name') != '' then (import './addons/grafana-on-gcp-oauth.libsonnet') else {}) +
+  (if std.extVar('is_preview_env') then (import './addons/preview-env.libsonnet') else (import './addons/cluster-monitoring.libsonnet'))
+  {
+    values+:: {
+      common+: {
+        namespace: std.extVar('namespace'),
+      },
+
+      gitpodParams: {
+        namespace: std.extVar('namespace'),
+        gitpodNamespace: 'default',
+        prometheusLabels: $.prometheus.prometheus.metadata.labels,
+        mixin+: { ruleLabels: $.values.common.ruleLabels },
+      },
+
+      prometheus+: {
+        replicas: 1,
+        externalLabels: {
+          cluster: std.extVar('cluster_name'),
+        },
+      },
+
+      alertmanager+: {
+        replicas: 1,
+      },
+
+      grafana+: {
+        dashboards+: $.gitpod.mixin.grafanaDashboards,
+      },
+
+    },
+
+    gitpod: gitpod($.values.gitpodParams),
+    alertmanager+: {
+      prometheusRule+: (import './lib/alert-severity-mapper.libsonnet') + (import './lib/alert-filter.libsonnet'),
+    },
+    kubeStateMetrics+: {
+      prometheusRule+: (import './lib/alert-severity-mapper.libsonnet') + (import './lib/alert-filter.libsonnet'),
+    },
+    kubernetesControlPlane+: {
+      prometheusRule+: (import './lib/alert-severity-mapper.libsonnet') + (import './lib/alert-filter.libsonnet'),
+    },
+    nodeExporter+: {
+      prometheusRule+: (import './lib/alert-severity-mapper.libsonnet') + (import './lib/alert-filter.libsonnet'),
+    },
+    prometheus+: {
+      prometheusRule+: (import './lib/alert-severity-mapper.libsonnet') + (import './lib/alert-filter.libsonnet'),
+    },
+    prometheusOperator+: {
+      prometheusRule+: (import './lib/alert-severity-mapper.libsonnet') + (import './lib/alert-filter.libsonnet'),
+    },
+    kubePrometheus+: {
+      namespace+: {
+        metadata+: {
+          labels+: {
+            namespace: std.extVar('namespace'),
+          },
+        },
+      },
+      prometheusRule+: (import './lib/alert-severity-mapper.libsonnet') + (import './lib/alert-filter.libsonnet'),
+    },
+  }
+;
+[
+  kp.kubePrometheus.namespace,
+  kp.restrictedPodSecurityPolicy,
+] +
+[kp.kubeStateMetrics[name] for name in std.objectFields(kp.kubeStateMetrics)]

--- a/monitoring-satellite/main-argo-test.jsonnet
+++ b/monitoring-satellite/main-argo-test.jsonnet
@@ -1,16 +1,16 @@
-local gitpod = import './components/gitpod/gitpod.libsonnet';
+local gitpod = import '../components/gitpod/gitpod.libsonnet';
 
 local kp =
   (import 'kube-prometheus/main.libsonnet') +
   (import 'kube-prometheus/platforms/gke.libsonnet') +
   (import 'kube-prometheus/addons/podsecuritypolicies.libsonnet') +
-  (import './addons/disable-grafana-auth.libsonnet') +
+  (import '../addons/disable-grafana-auth.libsonnet') +
   (import 'kube-prometheus/addons/strip-limits.libsonnet') +
-  (import './addons/gitpod-runbooks.libsonnet') +
-  (if std.extVar('remote_write_url') != '' then (import './addons/remote-write.libsonnet') else {}) +
-  (if std.extVar('slack_webhook_url_critical') != '' then (import './addons/slack-alerting.libsonnet') else {}) +
-  (if std.extVar('dns_name') != '' then (import './addons/grafana-on-gcp-oauth.libsonnet') else {}) +
-  (if std.extVar('is_preview_env') then (import './addons/preview-env.libsonnet') else (import './addons/cluster-monitoring.libsonnet'))
+  (import '../addons/gitpod-runbooks.libsonnet') +
+  (if std.extVar('remote_write_url') != '' then (import '../addons/remote-write.libsonnet') else {}) +
+  (if std.extVar('slack_webhook_url_critical') != '' then (import '../addons/slack-alerting.libsonnet') else {}) +
+  (if std.extVar('dns_name') != '' then (import '../addons/grafana-on-gcp-oauth.libsonnet') else {}) +
+  (if std.extVar('is_preview_env') then (import '../addons/preview-env.libsonnet') else (import '../addons/cluster-monitoring.libsonnet'))
   {
     values+:: {
       common+: {
@@ -43,22 +43,22 @@ local kp =
 
     gitpod: gitpod($.values.gitpodParams),
     alertmanager+: {
-      prometheusRule+: (import './lib/alert-severity-mapper.libsonnet') + (import './lib/alert-filter.libsonnet'),
+      prometheusRule+: (import '../lib/alert-severity-mapper.libsonnet') + (import '../lib/alert-filter.libsonnet'),
     },
     kubeStateMetrics+: {
-      prometheusRule+: (import './lib/alert-severity-mapper.libsonnet') + (import './lib/alert-filter.libsonnet'),
+      prometheusRule+: (import '../lib/alert-severity-mapper.libsonnet') + (import '../lib/alert-filter.libsonnet'),
     },
     kubernetesControlPlane+: {
-      prometheusRule+: (import './lib/alert-severity-mapper.libsonnet') + (import './lib/alert-filter.libsonnet'),
+      prometheusRule+: (import '../lib/alert-severity-mapper.libsonnet') + (import '../lib/alert-filter.libsonnet'),
     },
     nodeExporter+: {
-      prometheusRule+: (import './lib/alert-severity-mapper.libsonnet') + (import './lib/alert-filter.libsonnet'),
+      prometheusRule+: (import '../lib/alert-severity-mapper.libsonnet') + (import '../lib/alert-filter.libsonnet'),
     },
     prometheus+: {
-      prometheusRule+: (import './lib/alert-severity-mapper.libsonnet') + (import './lib/alert-filter.libsonnet'),
+      prometheusRule+: (import '../lib/alert-severity-mapper.libsonnet') + (import '../lib/alert-filter.libsonnet'),
     },
     prometheusOperator+: {
-      prometheusRule+: (import './lib/alert-severity-mapper.libsonnet') + (import './lib/alert-filter.libsonnet'),
+      prometheusRule+: (import '../lib/alert-severity-mapper.libsonnet') + (import '../lib/alert-filter.libsonnet'),
     },
     kubePrometheus+: {
       namespace+: {
@@ -68,7 +68,7 @@ local kp =
           },
         },
       },
-      prometheusRule+: (import './lib/alert-severity-mapper.libsonnet') + (import './lib/alert-filter.libsonnet'),
+      prometheusRule+: (import '../lib/alert-severity-mapper.libsonnet') + (import '../lib/alert-filter.libsonnet'),
     },
   }
 ;


### PR DESCRIPTION
This PR, when ready, should refactor our whole deployment strategy for this repository to be compatible with ArgoCD.

The problem right now is that we create YAML files with our output instead of just printing to stdout valid Kubernetes resources, which is what ArgoCD expects. 

This draft prints an array of valid kubernetes resources to stdout by running the command:
```shell
jsonnet -J vendor \
--ext-str namespace=${NAMESPACE:-cluster-monitoring} \
--ext-str cluster_name=${CLUSTER_NAME:-cluster01} \
--ext-str remote_write_url=${REMOTE_WRITE_URL:-''} \
--ext-str slack_webhook_url_critical=${SLACK_WEBHOOK_URL_CRITICAL:-""} \
--ext-str slack_webhook_url_warning=${SLACK_WEBHOOK_URL_WARNING:-""} \
--ext-str slack_webhook_url_info=${SLACK_WEBHOOK_URL_INFO:-""} \
--ext-str slack_channel_prefix=${SLACK_CHANNEL_PREFIX:-""} \
--ext-str pagerduty_routing_key=${PAGERDUTY_ROUTING_KEY:-""} \
--ext-str grafana_ingress_node_port=${GRAFANA_INGRESS_NODE_PORT} \
--ext-str dns_name=${DNS_NAME:-''} \
--ext-str gcp_external_ip_address=${GCP_EXTERNAL_IP_ADDRESS} \
--ext-str IAP_client_id=${IAP_CLIENT_ID} \
--ext-str IAP_client_secret=${IAP_CLIENT_SECRET} \
--ext-code is_preview_env=${IS_PREVIEW_ENV:-false} \
"monitoring-satellite/main-argo-test.jsonnet"
```

I'd like to run a test on ArgoCD UI with this branch and `./monitoring-satellite` as path to certify that this is the expected output.