### PR TITLE
Put slack and pagerduty into the same receiver for critical alerts

### DIFF
--- a/addons/slack-alerting.libsonnet
+++ b/addons/slack-alerting.libsonnet
@@ -9,10 +9,7 @@
           group_by:
           - alertname
           routes:
-          - receiver: PagerDuty
-            match:
-              severity: critical
-          - receiver: SlackCritical
+          - receiver: CriticalReceivers
             match:
               severity: critical
           - receiver: SlackWarning
@@ -43,7 +40,7 @@
         receivers:
         - name: Black_Hole
         - name: Watchdog
-        - name: SlackCritical
+        - name: CriticalReceivers
           slack_configs:
           - send_resolved: true
             api_url: %(slackWebhookUrlCritical)s
@@ -61,6 +58,13 @@
             - type: button
               text: 'Runbook :book:'
               url: '{{ .CommonAnnotations.runbook_url }}'
+          pagerduty_configs:
+          - send_resolved: true
+            routing_key: '%(pagerdutyRoutingKey)s'
+            description: '{{ .Annotations.description }}'
+            links:
+              - href: '{{ .CommonAnnotations.runbook_url }}'
+                text: 'Runbook'
         - name: SlackWarning
           slack_configs:
           - send_resolved: true
@@ -97,14 +101,6 @@
             - type: button
               text: 'Runbook :book:'
               url: '{{ .CommonAnnotations.runbook_url }}'
-        - name: PagerDuty
-          pagerduty_configs:
-          - send_resolved: true
-            routing_key: '%(pagerdutyRoutingKey)s'
-            description: '{{ .Annotations.description }}'
-            links:
-              - href: '{{ .CommonAnnotations.runbook_url }}'
-                text: 'Runbook'
         templates: []
       ||| % {
         clusterName: std.extVar('cluster_name'),


### PR DESCRIPTION
A better approach to solve #85 

<a href="https://gitpod.io/#https://github.com/gitpod-io/observability/pull/88"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

