### PR TITLE
components: add OpenTelemetry Collector

### DIFF
--- a/addons/preview-env.libsonnet
+++ b/addons/preview-env.libsonnet
@@ -1,4 +1,6 @@
 // The preview-environment addon provides json snippets that are specific for preview environment installations.
+local otelCollector = import '../components/open-telemetry-collector/open-telemetry-collector.libsonnet';
+
 {
   values+:: {
     // On preview env, Gitpod and monitoring satellite are installed in the same namespace.
@@ -6,10 +8,16 @@
       gitpodNamespace: std.extVar('namespace'),
     },
 
+    otelCollectorParams: {
+      namespace: std.extVar('namespace'),
+    },
+
     nodeExporter+: {
       port: std.parseInt(std.extVar('node_exporter_port')),
     },
   },
+
+  otelCollector: otelCollector($.values.otelCollectorParams),
 
   prometheus+: {
     prometheus+: {
@@ -116,7 +124,7 @@
         type: 'LoadBalancer',
       },
     },
-    
+
     certificate: {
       apiVersion: 'cert-manager.io/v1',
       kind: 'Certificate',

--- a/components/open-telemetry-collector/open-telemetry-collector.libsonnet
+++ b/components/open-telemetry-collector/open-telemetry-collector.libsonnet
@@ -1,0 +1,252 @@
+local defaults = {
+  defaults: self,
+
+  name: 'otel-collector',
+  namespace: error 'must provide namespace',
+  version: '0.38.0',
+  commonLabels: {
+    'app.kubernetes.io/name': defaults.name,
+    'app.kubernetes.io/part-of': 'kube-prometheus',
+  },
+};
+
+function(params) {
+  local otel = self,
+  _config:: defaults + params,
+
+  local collectorConfig =
+    |||
+      receivers:
+        jaeger:
+          protocols:
+            thrift_http:
+              endpoint: "0.0.0.0:14268"
+        otlp:
+          protocols:
+            grpc: # on port 4317
+            http: # on port 4318
+
+      processors:
+
+      exporters:
+        otlp:
+          endpoint: "api.honeycomb.io:443"
+          headers:
+            "x-honeycomb-team": "%(honeycomb_api_key)s"
+            "x-honeycomb-dataset": "%(honeycomb_dataset)s"
+
+      extensions:
+        health_check:
+        pprof:
+        zpages:
+
+      service:
+        telemetry:
+          logs:
+            level: "debug"
+        extensions: [health_check, pprof,  zpages]
+        pipelines:
+          traces:
+            receivers: [jaeger, otlp]
+            processors: []
+            exporters: [otlp]
+    ||| % {
+      honeycomb_api_key: std.extVar('honeycomb_api_key'),
+      honeycomb_dataset: std.extVar('honeycomb_dataset'),
+    },
+
+  configMap: {
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: {
+      name: otel._config.name,
+      namespace: otel._config.namespace,
+      labels: otel._config.commonLabels,
+    },
+    data: {
+      'collector.yaml': collectorConfig,
+    },
+  },
+
+  deployment: {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: otel._config.name,
+      namespace: otel._config.namespace,
+      labels: otel._config.commonLabels,
+    },
+    spec: {
+      replicas: 1,
+      selector: {
+        matchLabels: otel._config.commonLabels,
+      },
+      template: {
+        metadata: {
+          labels: otel._config.commonLabels,
+        },
+        spec: {
+          serviceAccountName: otel.serviceAccount.metadata.name,
+          containers: [
+            {
+              name: 'otelcol',
+              args: [
+                '--config=/conf/collector.yaml',
+              ],
+              image: 'otel/opentelemetry-collector:' + otel._config.version,
+              volumeMounts: [
+                {
+                  mountPath: '/conf',
+                  name: otel.configMap.metadata.name,
+                },
+              ],
+            },
+          ],
+          volumes: [
+            {
+              name: otel.configMap.metadata.name,
+              configMap: {
+                items: [
+                  {
+                    key: 'collector.yaml',
+                    path: 'collector.yaml',
+                  },
+                ],
+                name: otel.configMap.metadata.name,
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: otel._config.name,
+      namespace: otel._config.namespace,
+      labels: otel._config.commonLabels,
+    },
+    spec: {
+      ports: [
+        {
+          name: 'jaeger',
+          port: 14268,
+          protocol: 'TCP',
+          targetPort: 14268,
+        },
+        {
+          name: 'grpc-otlp',
+          port: 4317,
+          protocol: 'TCP',
+          targetPort: 4317,
+        },
+        {
+          name: 'metrics',
+          port: 8888,
+          protocol: 'TCP',
+          targetPort: 8888,
+        },
+      ],
+      selector: otel._config.commonLabels,
+      type: 'ClusterIP',
+    },
+  },
+
+  clusterRole: {
+    apiVersion: 'rbac.authorization.k8s.io/v1beta1',
+    kind: 'ClusterRole',
+    metadata: {
+      name: otel._config.name,
+      labels: otel._config.commonLabels,
+    },
+    rules: [{
+      apiGroups: ['policy'],
+      resources: ['podsecuritypolicies'],
+      verbs: ['use'],
+      resourceNames: [otel.podSecurityPolicy.metadata.name],
+    }],
+  },
+
+  clusterRoleBinding: {
+    apiVersion: 'rbac.authorization.k8s.io/v1beta1',
+    kind: 'ClusterRoleBinding',
+    metadata: {
+      name: otel._config.name,
+      labels: otel._config.commonLabels,
+    },
+    subjects: [{
+      kind: 'ServiceAccount',
+      name: otel.serviceAccount.metadata.name,
+      namespace: otel._config.namespace,
+    }],
+    roleRef: {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'ClusterRole',
+      name: otel.clusterRole.metadata.name,
+    },
+  },
+
+  podSecurityPolicy: {
+    apiVersion: 'policy/v1beta1',
+    kind: 'PodSecurityPolicy',
+    metadata: {
+      name: otel._config.name,
+      labels: otel._config.commonLabels,
+    },
+    spec: {
+      privileged: false,
+      seLinux: {
+        rule: 'RunAsAny',
+      },
+      supplementalGroups: {
+        rule: 'RunAsAny',
+      },
+      runAsUser: {
+        rule: 'RunAsAny',
+      },
+      fsGroup: {
+        rule: 'RunAsAny',
+      },
+      volumes: ['*'],
+    },
+  },
+
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: otel._config.name,
+      namespace: otel._config.namespace,
+      labels: otel._config.commonLabels,
+    },
+  },
+
+  serviceMonitor: {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'ServiceMonitor',
+    metadata: {
+      name: otel._config.name,
+      namespace: otel._config.namespace,
+      labels: otel._config.commonLabels,
+    },
+    spec: {
+      jobLabel: 'app.kubernetes.io/name',
+      selector: {
+        matchLabels: otel._config.commonLabels,
+      },
+      namespaceSelector: {
+        matchNames: [
+          otel._config.namespace,
+        ],
+      },
+      endpoints: [{
+        bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+        port: 'metrics',
+        interval: '30s',
+      }],
+    },
+  },
+}

--- a/hack/deploy-satellite.sh
+++ b/hack/deploy-satellite.sh
@@ -22,3 +22,4 @@ kubectl apply -f monitoring-satellite/manifests/kubernetes/
 kubectl apply -f monitoring-satellite/manifests/kube-state-metrics/
 kubectl apply -f monitoring-satellite/manifests/grafana/
 kubectl apply -f monitoring-satellite/manifests/alertmanager/
+kubectl apply -f monitoring-satellite/manifests/otelCollector/

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -38,6 +38,8 @@ if [[ $environment == "CI" ]]; then
     --ext-str remote_write_username="user" \
     --ext-str prometheus_dns_name="prometheus.fake.preview.io" \
     --ext-str grafana_dns_name="grafana.fake.preview.io" \
+    --ext-str honeycomb_api_key="fake-key" \
+    --ext-str honeycomb_dataset="fake-dataset" \
     --ext-code remote_write_urls="['http://victoriametrics-vmauth.monitoring-central.svc:8427/api/v1/write']" \
     monitoring-satellite/manifests/continuous_integration.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 
@@ -66,6 +68,8 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
 --ext-str remote_write_username="user" \
 --ext-str prometheus_dns_name="prometheus.fake.preview.io" \
 --ext-str grafana_dns_name="grafana.fake.preview.io" \
+--ext-str honeycomb_api_key="fake-key" \
+--ext-str honeycomb_dataset="fake-dataset" \
 --ext-code remote_write_urls="['http://victoriametrics-vmauth.monitoring-central.svc:8427/api/v1/write']" \
 monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 
@@ -97,6 +101,8 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
 --ext-str alerting_enabled="false" \
 --ext-str remote_write_enabled="false" \
 --ext-str is_preview="false" \
+--ext-str honeycomb_api_key="fake-key" \
+--ext-str honeycomb_dataset="fake-dataset" \
 monitoring-satellite/manifests/rules.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 
 # Make sure to remove json files

--- a/monitoring-satellite/main.jsonnet
+++ b/monitoring-satellite/main.jsonnet
@@ -16,3 +16,7 @@ local monitoringSatellite = (import './monitoring-satellite.libsonnet');
 [monitoringSatellite.prometheusOperator[name] for name in std.objectFields(monitoringSatellite.prometheusOperator)] +
 [monitoringSatellite.certmanager[name] for name in std.objectFields(monitoringSatellite.certmanager)] +
 [monitoringSatellite.werft[name] for name in std.objectFields(monitoringSatellite.werft)]
+
+// Exposed by monitoring-satellite object, but we don't want to rollout yet:
+// [monitoringSatellite.otelCollector[name] for name in std.objectFields(monitoringSatellite.otelCollector)]
+

--- a/monitoring-satellite/manifests/continuous_integration.jsonnet
+++ b/monitoring-satellite/manifests/continuous_integration.jsonnet
@@ -12,4 +12,5 @@ local monitoringSatellite = (import '../monitoring-satellite.libsonnet') + (impo
 { ['kubernetes/' + name]: monitoringSatellite.kubernetesControlPlane[name] for name in std.objectFields(monitoringSatellite.kubernetesControlPlane) }
 { ['node-exporter/' + name]: monitoringSatellite.nodeExporter[name] for name in std.objectFields(monitoringSatellite.nodeExporter) } +
 { ['prometheus-operator/' + name]: monitoringSatellite.prometheusOperator[name] for name in std.objectFields(monitoringSatellite.prometheusOperator) } +
-{ ['certmanager/' + name]: monitoringSatellite.certmanager[name] for name in std.objectFields(monitoringSatellite.certmanager) }
+{ ['certmanager/' + name]: monitoringSatellite.certmanager[name] for name in std.objectFields(monitoringSatellite.certmanager) } +
+{ ['otelCollector/' + name]: monitoringSatellite.otelCollector[name] for name in std.objectFields(monitoringSatellite.otelCollector) }

--- a/monitoring-satellite/manifests/yaml-generator.jsonnet
+++ b/monitoring-satellite/manifests/yaml-generator.jsonnet
@@ -13,4 +13,5 @@ local monitoringSatellite = (import '../monitoring-satellite.libsonnet');
 { ['node-exporter/' + name]: monitoringSatellite.nodeExporter[name] for name in std.objectFields(monitoringSatellite.nodeExporter) } +
 { ['prometheus-operator/' + name]: monitoringSatellite.prometheusOperator[name] for name in std.objectFields(monitoringSatellite.prometheusOperator) } +
 { ['certmanager/' + name]: monitoringSatellite.certmanager[name] for name in std.objectFields(monitoringSatellite.certmanager) } +
-{ ['werft/' + name]: monitoringSatellite.werft[name] for name in std.objectFields(monitoringSatellite.werft) }
+{ ['werft/' + name]: monitoringSatellite.werft[name] for name in std.objectFields(monitoringSatellite.werft) } +
+{ ['otelCollector/' + name]: monitoringSatellite.otelCollector[name] for name in std.objectFields(monitoringSatellite.otelCollector) }

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -48,7 +48,7 @@ func testMain(m *testing.M) int {
 func TestDeployments(t *testing.T) {
 	kClient := promClient.kubeClient
 
-	apps := []string{"grafana", "kube-state-metrics", "prometheus-operator"}
+	apps := []string{"grafana", "kube-state-metrics", "prometheus-operator", "otel-collector"}
 
 	for _, app := range apps {
 		// Table-driven + parallel tests are quite tricky and require us


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds open-telemetry collector to monitoring-satellite

OpenTelemetry collector is being added to monitoring-satellite as a router that receiver Jaeger traces from Gitpod components and redirects them to a Honeycomb dataset.

At the moment it is only added to our CI pipeline and preview environments, it will be enabled to production in a following PR after experimentation.

