### PR TITLE
Changing certManagerCertExpiryDays to 7

### DIFF
--- a/monitoring-satellite/monitoring-satellite.libsonnet
+++ b/monitoring-satellite/monitoring-satellite.libsonnet
@@ -29,7 +29,12 @@ local werft = import '../components/werft/werft.libsonnet';
       namespace: std.extVar('namespace'),
       certmanagerNamespace: 'certmanager',
       prometheusLabels: $.prometheus.prometheus.metadata.labels,
-      mixin+: { ruleLabels: $.values.common.ruleLabels },
+      mixin+: {
+        ruleLabels: $.values.common.ruleLabels,
+        _config+: {
+          certManagerCertExpiryDays: 7,
+        },
+      },
     },
 
     werftParams: {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This sets the severity of the alert to critical. As 15 days is the default when certificates are renewed the alert is triggered 7 days before they expire.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/157
