### PR TITLE
Hide Otel-collector behind `tracing_enabled` external variable

### DIFF
--- a/addons/preview-env.libsonnet
+++ b/addons/preview-env.libsonnet
@@ -1,15 +1,10 @@
 // The preview-environment addon provides json snippets that are specific for preview environment installations.
-local otelCollector = import '../components/open-telemetry-collector/open-telemetry-collector.libsonnet';
 
 {
   values+:: {
     // On preview env, Gitpod and monitoring satellite are installed in the same namespace.
     gitpodParams+: {
       gitpodNamespace: std.extVar('namespace'),
-    },
-
-    otelCollectorParams: {
-      namespace: std.extVar('namespace'),
     },
 
     nodeExporter+: {
@@ -24,8 +19,6 @@ local otelCollector = import '../components/open-telemetry-collector/open-teleme
       },
     },
   },
-
-  otelCollector: otelCollector($.values.otelCollectorParams),
 
   prometheus+: {
     prometheus+: {

--- a/addons/tracing.libsonnet
+++ b/addons/tracing.libsonnet
@@ -1,0 +1,11 @@
+local otelCollector = import '../components/open-telemetry-collector/open-telemetry-collector.libsonnet';
+
+{
+  values+:: {
+    otelCollectorParams: {
+      namespace: std.extVar('namespace'),
+    },
+  },
+
+  otelCollector: otelCollector($.values.otelCollectorParams),
+}

--- a/hack/deploy-satellite.sh
+++ b/hack/deploy-satellite.sh
@@ -3,23 +3,24 @@
 kubectl apply -f monitoring-satellite/manifests/namespace.yaml
 kubectl apply -f monitoring-satellite/manifests/podsecuritypolicy-restricted.yaml
 
-kubectl create -f monitoring-satellite/manifests/prometheus-operator/0alertmanagerConfigCustomResourceDefinition.yaml
-kubectl create -f monitoring-satellite/manifests/prometheus-operator/0alertmanagerCustomResourceDefinition.yaml
-kubectl create -f monitoring-satellite/manifests/prometheus-operator/0podmonitorCustomResourceDefinition.yaml
-kubectl create -f monitoring-satellite/manifests/prometheus-operator/0probeCustomResourceDefinition.yaml
-kubectl create -f monitoring-satellite/manifests/prometheus-operator/0prometheusCustomResourceDefinition.yaml
-kubectl create -f monitoring-satellite/manifests/prometheus-operator/0prometheusruleCustomResourceDefinition.yaml
-kubectl create -f monitoring-satellite/manifests/prometheus-operator/0servicemonitorCustomResourceDefinition.yaml
-kubectl create -f monitoring-satellite/manifests/prometheus-operator/0thanosrulerCustomResourceDefinition.yaml
+for CRD in $(find monitoring-satellite/manifests/prometheusOperator/ -type f -name "*CustomResourceDefinition.yaml"); 
+do 
+  kubectl replace -f $CRD || kubectl create -f $CRD
+done
 
 until kubectl get servicemonitors.monitoring.coreos.com --all-namespaces ; do date; sleep 1; echo ""; done
 until kubectl get prometheusrules.monitoring.coreos.com --all-namespaces ; do date; sleep 1; echo ""; done
 
-kubectl apply -f monitoring-satellite/manifests/prometheus-operator/
+
+for operatorManifest in $(find monitoring-satellite/manifests/prometheusOperator/ -type f ! -name "*CustomResourceDefinition.yaml"); 
+do 
+  kubectl apply -f $operatorManifest
+done
+
 kubectl apply -f monitoring-satellite/manifests/prometheus/
-kubectl apply -f monitoring-satellite/manifests/node-exporter/
-kubectl apply -f monitoring-satellite/manifests/kubernetes/
-kubectl apply -f monitoring-satellite/manifests/kube-state-metrics/
+kubectl apply -f monitoring-satellite/manifests/nodeExporter/
+kubectl apply -f monitoring-satellite/manifests/kubernetesControlPlane/
+kubectl apply -f monitoring-satellite/manifests/kubeStateMetrics/
 kubectl apply -f monitoring-satellite/manifests/grafana/
 kubectl apply -f monitoring-satellite/manifests/alertmanager/
 kubectl apply -f monitoring-satellite/manifests/otelCollector/

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -38,6 +38,7 @@ if [[ $environment == "CI" ]]; then
     --ext-str remote_write_username="user" \
     --ext-str prometheus_dns_name="prometheus.fake.preview.io" \
     --ext-str grafana_dns_name="grafana.fake.preview.io" \
+    --ext-str tracing_enabled="true" \
     --ext-str honeycomb_api_key="fake-key" \
     --ext-str honeycomb_dataset="fake-dataset" \
     --ext-code remote_write_urls="['http://victoriametrics-vmauth.monitoring-central.svc:8427/api/v1/write']" \
@@ -68,6 +69,7 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
 --ext-str remote_write_username="user" \
 --ext-str prometheus_dns_name="prometheus.fake.preview.io" \
 --ext-str grafana_dns_name="grafana.fake.preview.io" \
+--ext-str tracing_enabled="true" \
 --ext-str honeycomb_api_key="fake-key" \
 --ext-str honeycomb_dataset="fake-dataset" \
 --ext-code remote_write_urls="['http://victoriametrics-vmauth.monitoring-central.svc:8427/api/v1/write']" \
@@ -101,6 +103,7 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
 --ext-str alerting_enabled="false" \
 --ext-str remote_write_enabled="false" \
 --ext-str is_preview="false" \
+--ext-str tracing_enabled="true" \
 --ext-str honeycomb_api_key="fake-key" \
 --ext-str honeycomb_dataset="fake-dataset" \
 monitoring-satellite/manifests/rules.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}

--- a/monitoring-satellite/main.jsonnet
+++ b/monitoring-satellite/main.jsonnet
@@ -1,22 +1,18 @@
 // This file is used to update monitoring-satellites with ArgoCD
 local monitoringSatellite = (import './monitoring-satellite.libsonnet');
+local excludedComponents = [
+  'blackboxExporter',
+  'kubePrometheus',
+  'restrictedPodSecurityPolicy',
+];
 
 [
   monitoringSatellite.kubePrometheus.namespace,
   monitoringSatellite.kubePrometheus.prometheusRule,
   monitoringSatellite.restrictedPodSecurityPolicy,
 ] +
-[monitoringSatellite.kubeStateMetrics[name] for name in std.objectFields(monitoringSatellite.kubeStateMetrics)] +
-[monitoringSatellite.grafana[name] for name in std.objectFields(monitoringSatellite.grafana)] +
-[monitoringSatellite.prometheus[name] for name in std.objectFields(monitoringSatellite.prometheus)] +
-[monitoringSatellite.gitpod[name] for name in std.objectFields(monitoringSatellite.gitpod)] +
-[monitoringSatellite.alertmanager[name] for name in std.objectFields(monitoringSatellite.alertmanager)] +
-[monitoringSatellite.kubernetesControlPlane[name] for name in std.objectFields(monitoringSatellite.kubernetesControlPlane)] +
-[monitoringSatellite.nodeExporter[name] for name in std.objectFields(monitoringSatellite.nodeExporter)] +
-[monitoringSatellite.prometheusOperator[name] for name in std.objectFields(monitoringSatellite.prometheusOperator)] +
-[monitoringSatellite.certmanager[name] for name in std.objectFields(monitoringSatellite.certmanager)] +
-[monitoringSatellite.werft[name] for name in std.objectFields(monitoringSatellite.werft)]
-
-// Exposed by monitoring-satellite object, but we don't want to rollout yet:
-// [monitoringSatellite.otelCollector[name] for name in std.objectFields(monitoringSatellite.otelCollector)]
-
+[
+  monitoringSatellite[component][resource]
+  for component in std.filter(function(component) !std.member(excludedComponents, component), std.objectFields(monitoringSatellite))
+  for resource in std.objectFields(monitoringSatellite[component],)
+]

--- a/monitoring-satellite/manifests/continuous_integration.jsonnet
+++ b/monitoring-satellite/manifests/continuous_integration.jsonnet
@@ -1,16 +1,16 @@
 // This file is used to update monitoring-satellites with ArgoCD
 local monitoringSatellite = (import '../monitoring-satellite.libsonnet') + (import '../../addons/continuous_integration.libsonnet');
+local excludedComponents = [
+  'blackboxExporter',
+  'kubePrometheus',
+  'restrictedPodSecurityPolicy',
+];
 
 { namespace: monitoringSatellite.kubePrometheus.namespace } +
 { 'podsecuritypolicy-restricted': monitoringSatellite.restrictedPodSecurityPolicy } +
 { 'prometheus/kube-prometheus-prometheusRule': monitoringSatellite.kubePrometheus.prometheusRule } +
-{ ['grafana/' + name]: monitoringSatellite.grafana[name] for name in std.objectFields(monitoringSatellite.grafana) } +
-{ ['prometheus/' + name]: monitoringSatellite.prometheus[name] for name in std.objectFields(monitoringSatellite.prometheus) } +
-{ ['gitpod/' + name]: monitoringSatellite.gitpod[name] for name in std.objectFields(monitoringSatellite.gitpod) } +
-{ ['alertmanager/' + name]: monitoringSatellite.alertmanager[name] for name in std.objectFields(monitoringSatellite.alertmanager) } +
-{ ['kube-state-metrics/' + name]: monitoringSatellite.kubeStateMetrics[name] for name in std.objectFields(monitoringSatellite.kubeStateMetrics) } +
-{ ['kubernetes/' + name]: monitoringSatellite.kubernetesControlPlane[name] for name in std.objectFields(monitoringSatellite.kubernetesControlPlane) }
-{ ['node-exporter/' + name]: monitoringSatellite.nodeExporter[name] for name in std.objectFields(monitoringSatellite.nodeExporter) } +
-{ ['prometheus-operator/' + name]: monitoringSatellite.prometheusOperator[name] for name in std.objectFields(monitoringSatellite.prometheusOperator) } +
-{ ['certmanager/' + name]: monitoringSatellite.certmanager[name] for name in std.objectFields(monitoringSatellite.certmanager) } +
-{ ['otelCollector/' + name]: monitoringSatellite.otelCollector[name] for name in std.objectFields(monitoringSatellite.otelCollector) }
+{
+  [component + '/' + resource]: monitoringSatellite[component][resource]
+  for component in std.filter(function(component) !std.member(excludedComponents, component), std.objectFields(monitoringSatellite))
+  for resource in std.objectFields(monitoringSatellite[component],)
+}

--- a/monitoring-satellite/manifests/yaml-generator.jsonnet
+++ b/monitoring-satellite/manifests/yaml-generator.jsonnet
@@ -1,17 +1,16 @@
 // This file is used to generate YAMLs for testing purposes.
 local monitoringSatellite = (import '../monitoring-satellite.libsonnet');
+local excludedComponents = [
+  'blackboxExporter',
+  'kubePrometheus',
+  'restrictedPodSecurityPolicy',
+];
 
 { namespace: monitoringSatellite.kubePrometheus.namespace } +
 { 'podsecuritypolicy-restricted': monitoringSatellite.restrictedPodSecurityPolicy } +
 { 'prometheus/kube-prometheus-prometheusRule': monitoringSatellite.kubePrometheus.prometheusRule } +
-{ ['grafana/' + name]: monitoringSatellite.grafana[name] for name in std.objectFields(monitoringSatellite.grafana) } +
-{ ['prometheus/' + name]: monitoringSatellite.prometheus[name] for name in std.objectFields(monitoringSatellite.prometheus) } +
-{ ['gitpod/' + name]: monitoringSatellite.gitpod[name] for name in std.objectFields(monitoringSatellite.gitpod) } +
-{ ['alertmanager/' + name]: monitoringSatellite.alertmanager[name] for name in std.objectFields(monitoringSatellite.alertmanager) } +
-{ ['kube-state-metrics/' + name]: monitoringSatellite.kubeStateMetrics[name] for name in std.objectFields(monitoringSatellite.kubeStateMetrics) } +
-{ ['kubernetes/' + name]: monitoringSatellite.kubernetesControlPlane[name] for name in std.objectFields(monitoringSatellite.kubernetesControlPlane) }
-{ ['node-exporter/' + name]: monitoringSatellite.nodeExporter[name] for name in std.objectFields(monitoringSatellite.nodeExporter) } +
-{ ['prometheus-operator/' + name]: monitoringSatellite.prometheusOperator[name] for name in std.objectFields(monitoringSatellite.prometheusOperator) } +
-{ ['certmanager/' + name]: monitoringSatellite.certmanager[name] for name in std.objectFields(monitoringSatellite.certmanager) } +
-{ ['werft/' + name]: monitoringSatellite.werft[name] for name in std.objectFields(monitoringSatellite.werft) } +
-{ ['otelCollector/' + name]: monitoringSatellite.otelCollector[name] for name in std.objectFields(monitoringSatellite.otelCollector) }
+{
+  [component + '/' + resource]: monitoringSatellite[component][resource]
+  for component in std.filter(function(component) !std.member(excludedComponents, component), std.objectFields(monitoringSatellite))
+  for resource in std.objectFields(monitoringSatellite[component],)
+}

--- a/monitoring-satellite/monitoring-satellite.libsonnet
+++ b/monitoring-satellite/monitoring-satellite.libsonnet
@@ -12,6 +12,7 @@ local werft = import '../components/werft/werft.libsonnet';
 (import '../addons/cluster-monitoring.libsonnet') +
 (if std.extVar('remote_write_enabled') == 'true' then (import '../addons/remote-write.libsonnet') else {}) +
 (if std.extVar('alerting_enabled') == 'true' then (import '../addons/alerting.libsonnet') else {}) +
+(if std.extVar('tracing_enabled') == 'true' then (import '../addons/tracing.libsonnet') else {}) +
 {
   values+:: {
     common+: {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We're making 2 changes here:
* Hid tracing components behind `tracing_enabled` external variable.
* Simplified deployment logic

I wanted to make the refactoring of deployment logic in a separate PR, but[ there is a problem if we did it](https://github.com/gitpod-io/observability/pull/29#discussion_r755391916).

To solve this problem we're now iterating over all existing objects inside the monitoring-satellite object



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #27 
