### PR TITLE
components/otel-collector: Make honeycomb and jaeger exporters config opt-in

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -40,6 +40,7 @@ if [[ $environment == "CI" ]]; then
     --ext-str grafana_dns_name="grafana.fake.preview.io" \
     --ext-str honeycomb_api_key="fake-key" \
     --ext-str honeycomb_dataset="fake-dataset" \
+    --ext-str jaeger_endpoint="http://jaeger:14268/api/traces" \
     --ext-code remote_write_urls="['http://victoriametrics-vmauth.monitoring-central.svc:8427/api/v1/write']" \
     monitoring-satellite/manifests/continuous_integration.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 
@@ -70,6 +71,7 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
 --ext-str grafana_dns_name="grafana.fake.preview.io" \
 --ext-str honeycomb_api_key="fake-key" \
 --ext-str honeycomb_dataset="fake-dataset" \
+--ext-str jaeger_endpoint="http://jaeger:14268/api/traces" \
 --ext-code remote_write_urls="['http://victoriametrics-vmauth.monitoring-central.svc:8427/api/v1/write']" \
 monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 
@@ -103,6 +105,7 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
 --ext-str is_preview="false" \
 --ext-str honeycomb_api_key="fake-key" \
 --ext-str honeycomb_dataset="fake-dataset" \
+--ext-str jaeger_endpoint="http://jaeger:14268/api/traces" \
 monitoring-satellite/manifests/rules.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 
 # Make sure to remove json files


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
To provide backward compatibility with what we have in our environments, we're making it possible to send traces to honeycomb, jaeger, or both at the same time.

To opt-in to any of the tracing backend, one just needs to set their corresponding external-variables.

If `honeycomb_api_key` is not an empty string, then the honeycomb exporter will be configured.
If `jaeger_endpoint` is not an empty string, then the jaeger exporter will be configured.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #26 
