### PR TITLE
changed certManagerCertExpiryDays to 7 days

### DIFF
--- a/monitoring-satellite/monitoring-satellite.libsonnet
+++ b/monitoring-satellite/monitoring-satellite.libsonnet
@@ -29,7 +29,12 @@ local werft = import '../components/werft/werft.libsonnet';
       namespace: std.extVar('namespace'),
       certmanagerNamespace: 'certmanager',
       prometheusLabels: $.prometheus.prometheus.metadata.labels,
-      mixin+: { ruleLabels: $.values.common.ruleLabels },
+      mixin+: {
+        ruleLabels: $.values.common.ruleLabels,
+        _config+: {
+          certManagerCertExpiryDays: 7,
+        },
+      },
     },
 
     werftParams: {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Certificates managed by Cert-Manager are renewed automatically 15 days before they expire. Having alerts for 21 days might be triggered unecessarily. 7 days is enough time to react.

This follows up https://github.com/gitpod-io/observability/pull/19.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #157
