### PR TITLE
Add support for stackdriver datasource

### DIFF
--- a/addons/grafana-stackdriver-datasource.libsonnet
+++ b/addons/grafana-stackdriver-datasource.libsonnet
@@ -1,0 +1,25 @@
+local privateKey = '|\n' + std.extVar('stackdriver_private_key');
+
+{
+  values+:: {
+    grafana+: {
+      datasources+: [
+        {
+          name: 'Google Stackdriver',
+          type: 'stackdriver',
+          access: 'proxy',
+          jsonData: {
+            tokenUri: 'https://oauth2.googleapis.com/token',
+            authenticationType: 'jwt',
+            clientEmail: std.extVar('stackdriver_client_email'),
+            defaultProject: std.extVar('stackdriver_default_project'),
+          },
+          secureJsonData: {
+            privateKey: privateKey,
+          },
+          editable: false,
+        },
+      ],
+    },
+  },
+}

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -43,6 +43,7 @@ if [[ $environment == "CI" ]]; then
     --ext-str honeycomb_dataset="fake-dataset" \
     --ext-str jaeger_endpoint="http://jaeger:14268/api/traces" \
     --ext-code remote_write_urls="['http://victoriametrics-vmauth.monitoring-central.svc:8427/api/v1/write']" \
+    --ext-str stackdriver_datasource_enabled="false" \
     monitoring-satellite/manifests/continuous_integration.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 
     # Make sure to remove json files
@@ -75,6 +76,7 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
 --ext-str honeycomb_dataset="fake-dataset" \
 --ext-str jaeger_endpoint="http://jaeger:14268/api/traces" \
 --ext-code remote_write_urls="['http://victoriametrics-vmauth.monitoring-central.svc:8427/api/v1/write']" \
+--ext-str stackdriver_datasource_enabled="false" \
 monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 
 # Generate monitoring-central YAML files
@@ -110,6 +112,7 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
 --ext-str honeycomb_api_key="fake-key" \
 --ext-str honeycomb_dataset="fake-dataset" \
 --ext-str jaeger_endpoint="http://jaeger:14268/api/traces" \
+--ext-str stackdriver_datasource_enabled="false" \
 monitoring-satellite/manifests/rules.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 
 # Make sure to remove json files

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -90,6 +90,7 @@ jsonnet -c -J vendor -m monitoring-central/manifests \
 --ext-str remote_write_password="p@ssW0rd" \
 --ext-str remote_write_username="user" \
 --ext-str vmauth_gcp_external_ip_address="fake_external_ip_address" \
+--ext-str stackdriver_datasource_enabled="false" \
 monitoring-central/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 
 # Generate monitoring-satellite prometheus rules

--- a/monitoring-central/monitoring-central.libsonnet
+++ b/monitoring-central/monitoring-central.libsonnet
@@ -7,7 +7,7 @@ local kubePrometheus =
   (import 'kube-prometheus/platforms/gke.libsonnet') +
   (import 'kube-prometheus/addons/podsecuritypolicies.libsonnet') +
   (import '../addons/disable-grafana-auth.libsonnet') +
-  (import '../addons/grafana-on-gcp-oauth.libsonnet')
+  (import '../addons/grafana-on-gcp-oauth.libsonnet') +
   {
     values+:: {
       common+: {
@@ -95,7 +95,12 @@ local kubePrometheus =
       // Disabling serviceMonitor for monitoring-central since there is no prometheus running there.
       serviceMonitor:: {},
     },
-  };
+  } +
+  
+  // We add this addon at the end because Jsonnet cares about order of execution.
+  // $.values.grafana.datasources is being completely overriden above to remove the prometheus datasource
+  // provided by kube-prometheus. If we add this addon before that, stackdriver datasource will also get erased.
+  (if std.extVar('stackdriver_datasource_enabled') == 'true' then (import '../addons/grafana-stackdriver-datasource.libsonnet') else {});
 
 
 kubePrometheus

--- a/monitoring-satellite/monitoring-satellite.libsonnet
+++ b/monitoring-satellite/monitoring-satellite.libsonnet
@@ -13,6 +13,7 @@ local werft = import '../components/werft/werft.libsonnet';
 (if std.extVar('remote_write_enabled') == 'true' then (import '../addons/remote-write.libsonnet') else {}) +
 (if std.extVar('alerting_enabled') == 'true' then (import '../addons/alerting.libsonnet') else {}) +
 (if std.extVar('tracing_enabled') == 'true' then (import '../addons/tracing.libsonnet') else {}) +
+(if std.extVar('stackdriver_datasource_enabled') == 'true' then (import '../addons/grafana-stackdriver-datasource.libsonnet') else {}) +
 {
   values+:: {
     common+: {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Alright, this is quite a sensitive Pull Request to test and merge. So let's proceed with caution 😬.

I was hoping that we could add this support only to monitoring-central, but we do need to also support this in monitoring-satellite because satellite is the only one getting deployed to preview environments and that's where our colleagues test their dashboards.

What I've implemented was add support for provisioning the Stackdriver datasource, according to the [official guide](https://grafana.com/docs/grafana/latest/datasources/google-cloud-monitoring/#configure-the-data-source-with-provisioning). While deploying the generated YAML into a kind cluster I was able to see the stackdriver datasource configured there, however, due to lack of the correct resources I still haven't tested this configuration end-to-end.

## Breaking changes

This PR introduces a new required external variable, therefore breaking every ArgoCD app, preview environment and the newly implemented [script that deploys monitoring-satellite to k3s clusters](https://github.com/gitpod-io/ops/blob/main/deploy/workspace/monitoring-satellite.sh).

New variables introduced:

| External Variable              	| Required                                             	| Description                                                	|
|--------------------------------	|------------------------------------------------------	|------------------------------------------------------------	|
| stackdriver_datasource_enabled 	| Yes                                                  	| Adds a stackdriver datasource to grafana                   	|
| stackdriver_client_email       	| If `stackdriver_datasource_enabled` is set to `true` 	| Email used to authenticate against Google Cloud.           	|
| stackdriver_default_project    	| If `stackdriver_datasource_enabled` is set to `true` 	| Default google project used when running queries.          	|
| stackdriver_private_key        	| If `stackdriver_datasource_enabled` is set to `true` 	| SSL Private key used to authenticate against Google Cloud. 	|

## How to test

My suggestion here is:

* Follow the [official guide](https://grafana.com/docs/grafana/latest/datasources/google-cloud-monitoring/#google-cloud-monitoring-settings) to generate all cloud resources that are needed in the `core-dev` project. (We probably want to do that via terraform)
* Change the [job definition](https://github.com/gitpod-io/gitpod/blob/main/.werft/build.yaml), adding the extra configuration as secrets.
* Spin up a new preview environment with stackdriver datasource enabled.
* Check if the grafana -> stackdriver connection works
* Repeat the first step, but for the remaining gcp projects (production and staging).
* Enable the datasource in the ArgoCD apps and at the workspace team's script


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #31 
