### PR TITLE
[otel] Use newer version of authorization resource

### DIFF
--- a/components/open-telemetry-collector/open-telemetry-collector.libsonnet
+++ b/components/open-telemetry-collector/open-telemetry-collector.libsonnet
@@ -193,7 +193,7 @@ function(params) {
   },
 
   clusterRole: {
-    apiVersion: 'rbac.authorization.k8s.io/v1beta1',
+    apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRole',
     metadata: {
       name: otel._config.name,
@@ -208,7 +208,7 @@ function(params) {
   },
 
   clusterRoleBinding: {
-    apiVersion: 'rbac.authorization.k8s.io/v1beta1',
+    apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleBinding',
     metadata: {
       name: otel._config.name,


### PR DESCRIPTION
rbac.authorization.k8s.io/v1beta1 is an older version which is removed in new version of kubernetes. Changed it to the latest version rbac.authorization.k8s.io/v1