### PR TITLE
monitoring-satellite: Make werft monitoring optional

### DIFF
--- a/addons/monitor-werft.libsonnet
+++ b/addons/monitor-werft.libsonnet
@@ -1,0 +1,21 @@
+local werft = import '../components/werft/werft.libsonnet';
+local defaults = {
+  namespace: 'werft',
+
+};
+
+function(config) {
+  local werftConfig = defaults + config.werft,
+
+  values+:: {
+    prometheus+: {
+      namespaces+: [werftConfig.namespace],
+    },
+  },
+
+  werft: werft({
+    namespace: config.namespace,
+    werftNamespace: werftConfig.namespace,
+    prometheusLabels: $.prometheus.prometheus.metadata.labels,
+  },),
+}

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -74,6 +74,9 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
             'kubernetes.io/os': 'linux',
         },
     },
+    werft: {
+        namespace: 'werft',
+    }
 }" \
 monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Following the refactoring done in #45, we're now making the resources used to monitor Werft optional.

To include then, one should include the "werft" object in the config.

`namespace` can be used to pass the namespace where werft is deployed. It has `werft` as the default value

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #24 

## How to test
<!-- Provide steps to test this PR -->
You can open a workspace from this branch, play around with different configurations under `hack/generate.sh`

## Caution
By merging this PR, all ArgoCD apps will delete the Werft-related resources from their deployments. This is exactly what we want for all of them, but the io-dev cluster.

We should open a PR downstream adding this extra config to io-dev