### PR TITLE
Monitoring-satellite/CRDs: Force replace on argocd sync

### DIFF
--- a/addons/argocd-crd-replace.libsonnet
+++ b/addons/argocd-crd-replace.libsonnet
@@ -1,0 +1,71 @@
+// Some CRDs are failing to be applied by argo with the following error:
+// CustomResourceDefinition.apiextensions.k8s.io "prometheuses.monitoring.coreos.com" is invalid: metadata.annotations: Too long: must have at most 262144 bytes
+//
+// This can be fixed by forcing the use of 'kubectl replace' when being synced by ArgoCD
+{
+  prometheusOperator+: {
+    '0alertmanagerConfigCustomResourceDefinition'+: {
+      metadata+: {
+        annotations+: {
+          'argocd.argoproj.io/sync-options': 'Replace=true',
+        },
+      },
+    },
+
+    '0alertmanagerCustomResourceDefinition'+: {
+      metadata+: {
+        annotations+: {
+          'argocd.argoproj.io/sync-options': 'Replace=true',
+        },
+      },
+    },
+
+    '0podmonitorCustomResourceDefinition'+: {
+      metadata+: {
+        annotations+: {
+          'argocd.argoproj.io/sync-options': 'Replace=true',
+        },
+      },
+    },
+
+    '0probeCustomResourceDefinition'+: {
+      metadata+: {
+        annotations+: {
+          'argocd.argoproj.io/sync-options': 'Replace=true',
+        },
+      },
+    },
+
+    '0prometheusCustomResourceDefinition'+: {
+      metadata+: {
+        annotations+: {
+          'argocd.argoproj.io/sync-options': 'Replace=true',
+        },
+      },
+    },
+
+    '0prometheusruleCustomResourceDefinition'+: {
+      metadata+: {
+        annotations+: {
+          'argocd.argoproj.io/sync-options': 'Replace=true',
+        },
+      },
+    },
+
+    '0servicemonitorCustomResourceDefinition'+: {
+      metadata+: {
+        annotations+: {
+          'argocd.argoproj.io/sync-options': 'Replace=true',
+        },
+      },
+    },
+
+    '0thanosrulerCustomResourceDefinition'+: {
+      metadata+: {
+        annotations+: {
+          'argocd.argoproj.io/sync-options': 'Replace=true',
+        },
+      },
+    },
+  },
+}

--- a/monitoring-satellite/monitoring-satellite.libsonnet
+++ b/monitoring-satellite/monitoring-satellite.libsonnet
@@ -10,6 +10,7 @@ local werft = import '../components/werft/werft.libsonnet';
 (import '../addons/disable-grafana-auth.libsonnet') +
 (import '../addons/ksm-extra-labels.libsonnet') +
 (import '../addons/metrics-relabeling.libsonnet') +
+(import '../addons/argocd-crd-replace.libsonnet') +
 (if std.objectHas(config, 'alerting') then (import '../addons/alerting.libsonnet')(config) else {}) +
 (if std.objectHas(config, 'remoteWrite') then (import '../addons/remote-write.libsonnet')(config) else {}) +
 (if std.objectHas(config, 'tracing') then (import '../addons/tracing.libsonnet')(config) else {}) +


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[Following ArgoCD docs](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/), we can enable per resource sync policy.

This PR forces all CRDs to be installed with `kubectl replace` instead of `kubectl apply`
