### PR TITLE
monitoring-central: Replace extVars with centralized configuration

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -79,17 +79,23 @@ monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {}
 
 # Generate monitoring-central YAML files
 jsonnet -c -J vendor -m monitoring-central/manifests \
---ext-str namespace="monitoring-central" \
---ext-str grafana_ingress_node_port=32164 \
---ext-str grafana_dns_name="http://fake.grafana.url" \
---ext-str gcp_external_ip_address="fake_external_ip_address" \
---ext-str IAP_client_id="fakeIAP_ID" \
---ext-str IAP_client_secret="fakeIAP_secret" \
---ext-str victoriametrics_dns_name="http://fake.victoriametrics.url" \
---ext-str vmauth_auth_key="random-key" \
---ext-str remote_write_password="p@ssW0rd" \
---ext-str remote_write_username="user" \
---ext-str vmauth_gcp_external_ip_address="fake_external_ip_address" \
+--ext-code config="{
+    namespace: 'monitoring-central',
+    grafana: {
+        nodePort: 32164,
+        DNS: 'http://fake.grafana.url',
+        GCPExternalIpAddress: 'fake_external_ip_address',
+        IAPClientID: 'fakeIAP_ID',
+        IAPClientSecret: 'fakeIAP_secret',
+    },
+    victoriametrics: {
+        DNS: 'http://fake.victoriametrics.url',
+        authKey: 'random-key',
+        username: 'p@ssW0rd',
+        password: 'user',
+        GCPExternalIpAddress: 'fake_external_ip_address',
+    }
+}" \
 monitoring-central/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 
 # Generate monitoring-satellite prometheus rules

--- a/monitoring-central/load-config.libsonnet
+++ b/monitoring-central/load-config.libsonnet
@@ -1,0 +1,9 @@
+// This file is only used to load default values and make some top-level assertions.
+
+local defaults = {
+  namespace: 'monitoring-central',
+};
+
+function(config) defaults + config {
+
+}

--- a/monitoring-central/monitoring-central.libsonnet
+++ b/monitoring-central/monitoring-central.libsonnet
@@ -1,3 +1,4 @@
+local config = (import 'load-config.libsonnet')(std.extVar('config'));
 local certmanager = import '../components/certmanager/certmanager.libsonnet';
 local gitpod = import '../components/gitpod/gitpod.libsonnet';
 local victoriaMetrics = import '../components/victoriametrics/victoriametrics.libsonnet';
@@ -7,14 +8,14 @@ local kubePrometheus =
   (import 'kube-prometheus/platforms/gke.libsonnet') +
   (import 'kube-prometheus/addons/podsecuritypolicies.libsonnet') +
   (import '../addons/disable-grafana-auth.libsonnet') +
-  (import '../addons/grafana-on-gcp-oauth.libsonnet')
+  (import '../addons/grafana-on-gcp-oauth.libsonnet')(config)
   {
     values+:: {
       common+: {
         namespace: 'monitoring-central',
       },
       gitpodParams: {
-        namespace: std.extVar('namespace'),
+        namespace: config.namespace,
       },
       certmanagerParams: {
         mixin+: {},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Following up the rewrite made in #45, this PR does the same thing but for monitoring-central.

## How to test
<!-- Provide steps to test this PR -->
Spin up a workspace from this branch, try different configurations at `hack/generate.sh`, run `make generate` and see the results.
