### PR TITLE
Use new labels for image builder

### DIFF
--- a/components/gitpod/gitpod.libsonnet
+++ b/components/gitpod/gitpod.libsonnet
@@ -400,12 +400,12 @@ function(params) {
       name: $._config.name + '-image-builder',
       namespace: $._config.gitpodNamespace,
       labels: $._config.commonLabels {
-        'app.kubernetes.io/component': 'image-builder',
+        'app.kubernetes.io/component': 'image-builder-mk3',
       },
     },
     spec: {
       selector: {
-        component: 'image-builder',
+        component: 'image-builder-mk3',
       },
       ports: [{
         name: 'metrics',
@@ -426,7 +426,7 @@ function(params) {
       jobLabel: 'app.kubernetes.io/component',
       selector: {
         matchLabels: $._config.commonLabels {
-          'app.kubernetes.io/component': 'image-builder',
+          'app.kubernetes.io/component': 'image-builder-mk3',
         },
       },
       namespaceSelector: {
@@ -453,7 +453,7 @@ function(params) {
     spec: {
       podSelector: {
         matchLabels: {
-          component: 'image-builder',
+          component: 'image-builder-mk3',
         },
       },
       policyTypes: ['Ingress'],


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We have migrated to a new image builder. This new image builder resources use label `image-builder-mk3` instead of older `image-builder`. Therefore, we need to update monitoring satellite to work against this newer version.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # NA

## How to test
<!-- Provide steps to test this PR -->
NA

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
