### PR TITLE
Assign reviews to platform

### DIFF
--- a/.github/workflows/dep-update.yaml
+++ b/.github/workflows/dep-update.yaml
@@ -39,7 +39,7 @@ jobs:
           delete-branch: true
           author: "Roboquat <roboquat@gitpod.io>"
           committer: "Roboquat <roboquat@gitpod.io>"
-          reviewers: "arthursens"
+          reviewers: "gitpod-io/platform"
           branch: "roboquat/automated-dependency-update-${{ matrix.branch }}"
           base: "${{ matrix.branch }}"
           # GITHUB_TOKEN cannot be used as it won't trigger CI in a created PR


### PR DESCRIPTION
## Description

We want to request reviews from the @gitpod-io/platform for dependency updates.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #59 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A
