### PR TITLE
increased resource for the grafana deployment

### DIFF
--- a/monitoring-central/monitoring-central.libsonnet
+++ b/monitoring-central/monitoring-central.libsonnet
@@ -27,6 +27,10 @@ local kubePrometheus =
         internalLoadBalancerIP: '10.32.0.25',
       },
       grafana+: {
+        resources: {
+          requests: { cpu: '1', memory: '1000Mi' },
+          limits: { cpu: '1', memory: '1000Mi' },
+        },
         dashboards:: {},
         folderDashboards+:: {
           'Team Platform': $.kubernetesControlPlane.mixin.grafanaDashboards + $.prometheus.mixin.grafanaDashboards + $.alertmanager.mixin.grafanaDashboards + $.certmanager.mixin.grafanaDashboards + $.nodeExporter.mixin.grafanaDashboards,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This increases the memory to 1GiB and 1 CPU for Grafana pods.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #54 

## How to test
<!-- Provide steps to test this PR -->
Run `make` and check the deployment manifest for Grafana.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
