### PR TITLE
workflows/dependencies-update: Enable auto-merge

### DIFF
--- a/.github/workflows/dep-update.yaml
+++ b/.github/workflows/dep-update.yaml
@@ -26,8 +26,10 @@ jobs:
           if [[ $changedFiles == "" ]]; then
             git checkout -- jsonnetfile.lock.json;
           fi
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
+        id: cpr
         with:
           commit-message: "[bot] [${{ matrix.branch }}] Automated dependencies update"
           title: "[bot] [${{ matrix.branch }}] Automated dependencies update"
@@ -45,3 +47,9 @@ jobs:
           # GITHUB_TOKEN cannot be used as it won't trigger CI in a created PR
           # More in https://github.com/peter-evans/create-pull-request/issues/155
           token: ${{ secrets.ROBOQUAT_PAT }}
+
+      - name: Enable auto-merge
+        uses: peter-evans/enable-pull-request-automerge@v1
+        with:
+          token: ${{ secrets.ROBOQUAT_PAT }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
 This PR adds another step to our `dependencies update` workflow, enabling auto-merge if all requirements pass (So far only e2e tests are required)

This is being done to reduce manual effort of approving and merging those PRs. If e2e tests are green then we shouldn't worry about it... if tests pass and we end up breaking stuff anyways, we need to understand and fix our e2e tests

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #67

## How to test
<!-- Provide steps to test this PR -->
Run the update-dependencies workflow from this branch. One example can be seen [here](https://github.com/gitpod-io/observability/pull/73)
