### PR TITLE
Add stackdriver support

### DIFF
--- a/addons/grafana-stackdriver-datasource.libsonnet
+++ b/addons/grafana-stackdriver-datasource.libsonnet
@@ -1,0 +1,41 @@
+function(config) {
+
+  assert std.objectHas(config.stackdriver, 'privateKey') : (
+    "If 'stackdriver' is set, 'privateKey' should be declared"
+  ),
+
+  assert std.objectHas(config.stackdriver, 'clientEmail') : (
+    "If 'stackdriver' is set, 'clientEmail' should be declared"
+  ),
+
+  assert std.objectHas(config.stackdriver, 'defaultProject') : (
+    "If 'stackdriver' is set, 'defaultProject' should be declared"
+  ),
+
+  local privateKey =
+    |||
+      %(privateKey)s
+    ||| % config.stackdriver,
+
+  values+:: {
+    grafana+: {
+      datasources+: [
+        {
+          name: 'Google Stackdriver',
+          type: 'stackdriver',
+          access: 'proxy',
+          jsonData: {
+            tokenUri: 'https://oauth2.googleapis.com/token',
+            authenticationType: 'jwt',
+            clientEmail: config.stackdriver.clientEmail,
+            defaultProject: config.stackdriver.defaultProject,
+          },
+          secureJsonData: {
+            privateKey: privateKey,
+          },
+          editable: false,
+        },
+      ],
+    },
+  },
+}

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -74,7 +74,17 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
     },
     werft: {
         namespace: 'werft',
-    }
+    },
+    stackdriver: {
+        clientEmail: 'fake@email.com',
+        defaultProject: 'google-project',
+        privateKey: 
+|||
+  multiline
+  fake
+  key
+|||,
+    },
 }" \
 monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 
@@ -95,7 +105,17 @@ jsonnet -c -J vendor -m monitoring-central/manifests \
         username: 'p@ssW0rd',
         password: 'user',
         GCPExternalIpAddress: 'fake_external_ip_address',
-    }
+    },
+    stackdriver: {
+        clientEmail: 'fake@email.com',
+        defaultProject: 'google-project',
+        privateKey: 
+|||
+  multiline
+  fake
+  key
+|||,
+    },
 }" \
 monitoring-central/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 

--- a/monitoring-central/monitoring-central.libsonnet
+++ b/monitoring-central/monitoring-central.libsonnet
@@ -8,7 +8,8 @@ local kubePrometheus =
   (import 'kube-prometheus/platforms/gke.libsonnet') +
   (import 'kube-prometheus/addons/podsecuritypolicies.libsonnet') +
   (import '../addons/disable-grafana-auth.libsonnet') +
-  (import '../addons/grafana-on-gcp-oauth.libsonnet')(config)
+  (import '../addons/grafana-on-gcp-oauth.libsonnet')(config) +
+  (if std.objectHas(config, 'stackdriver') then (import '../addons/grafana-stackdriver-datasource.libsonnet')(config) else {}) +
   {
     values+:: {
       common+: {

--- a/monitoring-satellite/monitoring-satellite.libsonnet
+++ b/monitoring-satellite/monitoring-satellite.libsonnet
@@ -14,6 +14,7 @@ local gitpod = import '../components/gitpod/gitpod.libsonnet';
 (if std.objectHas(config, 'remoteWrite') then (import '../addons/remote-write.libsonnet')(config) else {}) +
 (if std.objectHas(config, 'tracing') then (import '../addons/tracing.libsonnet')(config) else {}) +
 (if std.objectHas(config, 'werft') then (import '../addons/monitor-werft.libsonnet')(config) else {}) +
+(if std.objectHas(config, 'stackdriver') then (import '../addons/grafana-stackdriver-datasource.libsonnet')(config) else {}) +
 {
   values+:: {
     common+: {


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Added a new addon to our project, which enables stackdriver datasource support to Grafana in monitoring-central and monitoring-satellite.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #31 

## How to test
<!-- Provide steps to test this PR -->
I've started a preview environment from this branch, which can be seen [here](https://werft.gitpod-dev.com/job/gitpod-build-as-stackdriver.3).

If you access Grafana in that environment, you'll see the Stackdriver datasource added and fully functional.
I had to hardcode secrets in the CI job to be able to spin up Grafana with stackdriver, so I won't commit the changes. Happy to show the changes in a call if the reviewer wants to  :)
