### PR TITLE
monitoring-central: Fix override ordering

### DIFF
--- a/monitoring-central/monitoring-central.libsonnet
+++ b/monitoring-central/monitoring-central.libsonnet
@@ -9,7 +9,6 @@ local kubePrometheus =
   (import 'kube-prometheus/addons/podsecuritypolicies.libsonnet') +
   (import '../addons/disable-grafana-auth.libsonnet') +
   (import '../addons/grafana-on-gcp-oauth.libsonnet')(config) +
-  (if std.objectHas(config, 'stackdriver') then (import '../addons/grafana-stackdriver-datasource.libsonnet')(config) else {}) +
   {
     values+:: {
       common+: {
@@ -101,7 +100,11 @@ local kubePrometheus =
       // Disabling serviceMonitor for monitoring-central since there is no prometheus running there.
       serviceMonitor:: {},
     },
-  };
+  } +
+  // This addon is being added at the bottom because Jsonnet is concious about code ordering.
+  // Above we override all datasources with victoriametrics.
+  // If this addon is kept above, it will be overriden as well.
+  (if std.objectHas(config, 'stackdriver') then (import '../addons/grafana-stackdriver-datasource.libsonnet')(config) else {});
 
 
 kubePrometheus


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Jsonnet cares about code ordering.

Let me try to explain what is happening today:
* We're using kube-prometheus, which includes a prometheus datasource by default
* We are including the addon which includes stackdriver
* Some lines we're trying to get rid of the non-existing Prometheus datasource, but endup overriding stackdriver as well


This PR changes the ordering so this can happen:
* We're using kube-prometheus, which includes a prometheus datasource by default
* We override the Prometheus datasource with VictoriaMetrics
* We include the stackdriver addon

---

I've noticed this when making sure the stackdriver datasource was already in prod