### PR TITLE
Document monitoring-satellite and monitoring-central with protobuf

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,4 @@
+---
 # TODO(arthursens): The image below has way more than it's needed for this project.
 # Need to come up with a minimal image with no more than necessary.
 image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-dev-image.0
@@ -9,3 +10,4 @@ tasks:
 vscode:
   extensions:
     - heptio.jsonnet
+    - zxh404.vscode-proto3

--- a/README.md
+++ b/README.md
@@ -28,43 +28,17 @@ Monitoring-satellite is composed by a set of components responsible for collecti
 * [Prometheus-Operator](https://github.com/prometheus-operator/prometheus-operator)
 * [OpenTelemetry-Collector](https://github.com/open-telemetry/opentelemetry-collector) (If tracing support is enabled)
 
-The monitoring-satellite's components can be customized by setting up different values for several Jsonnet external-variables. Some of those external variables are required (even if left empty), and other can become required depending on the values of other variables. The complete list can be seen below:
+To customize the stack, we make use of Jsonnet's [external-variables feature](https://jsonnet.org/ref/stdlib.html). We expect one single external variable called `config` which is loaded and merged with monitoring-satellite to customize the stack.
 
-| External Variable          	| Required                                                                              	| Description                                                                                                                                                    	|
-|----------------------------	|---------------------------------------------------------------------------------------	|----------------------------------------------------------------------------------------------------------------------------------------------------------------	|
-| namespace                  	| Yes                                                                                   	| Namespace where all components will be deployed                                                                                                                	|
-| cluster_name               	| Yes                                                                                   	| Value of the Prometheus' external label `cluster`.                                                                                                             	|
-| is_preview                 	| Yes                                                                                   	| If set to `true`, will make several changes required to run monitoring-satellite in preview environments. See `addons/preview-env.libsonnet` for more details. 	|
-| remote_write_enabled       	| Yes                                                                                   	| If set to `true`, will configure Prometheus to send metrics to a remote-backend.                                                                               	|
-| alerting_enabled           	| Yes                                                                                   	| If set to `true`, will configure alert routing to slack/pagerduty.                                                                                             	|
-| tracing_enabled            	| Yes                                                                                   	| If set to `true`, will add OpenTelemetry-Collector to monitoring-satellite. The collector can be configure to send traces to Honeycomb and/or Jaeger.          	|
-| node_affinity_label        	| Yes                                                                                   	| If different from an empty string, will set up node affinity to all components of monitoring-satellite.                                                        	|
-| remote_write_urls          	| If `remote_write_enabled` is set to `true`                                            	| URLs where prometheus will send metrics to.                                                                                                                    	|
-| remote_write_username      	| If `remote_write_enabled` is set to `true`                                            	| Username used to authenticate against the remote-write endpoint.                                                                                               	|
-| remote_write_password      	| If `remote_write_enabled` is set to `true`                                            	| Password used to authenticate against the remote-write endpoint.                                                                                               	|
-| pagerduty_routing_key      	| If `alerting_enabled` is set to `true`                                                	| Pagerduty Routing key used to route `critical` alerts. If set to an empty string, `slack_webhook_url_critical` will take preference.                           	|
-| slack_webhook_url_critical 	| If `alerting_enabled` is set to `true` and `pagerduty_routing_key` is an empty string 	| Slack webhook URL used to route `critical` alerts.                                                                                                             	|
-| slack_webhook_url_warning  	| If `alerting_enabled` is set to `true`                                                	| Slack webhook URL used to route `warning` alerts.                                                                                                              	|
-| slack_webhook_url_info     	| If `alerting_enabled` is set to `true`                                                	| Slack webhook URL used to route `info` alerts.                                                                                                                 	|
-| slack_channel_prefix       	| If `alerting_enabled` is set to `true`                                                	| Prefix of the slack channels where alerts are being routed to.                                                                                                 	|
-| honeycomb_api_key          	| If `tracing_enabled` is set to `true`                                                 	| Honeycomb API key used to push traces to honeycomb. Leave as an empty string to not send traces to Honeycomb.                                                  	|
-| honeycomb_dataset          	| If `tracing_enabled` is set to `true` and `honeycomb_api_key` is not an empty string  	| Dataset where traces are going to be stored.                                                                                                                   	|
-| jaeger_endpoint            	| If `tracing_enabled` is set to `true`                                                 	| Jaeger HTTP endpoint where traces are going to be pushed to. Leave as an empty string to not send traces to Jaeger.                                            	|
-| node_exporter_port         	| If `is_preview` is set to `true`                                                      	| Port used by the node-exporter daemonset.                                                                                                                      	|
-| prometheus_dns_name        	| If `is_preview` is set to `true`                                                      	| DNS used to configure Prometheus's certificate and ingress.                                                                                                    	|
-| grafana_dns_name           	| If `is_preview` is set to `true`                                                      	| DNS used to configure Grafanas's certificate and ingress.                                                                                                      	|
+We expect `config` to be a JSON object, where extra configuration can be added as we develop new features for monitoring-satellite. For more details, please check [monitoring-satellite data schema](docs/monitoring-satellite.proto).
 
-
-Therefore, the simplest command that can be used to generate monitoring-satellite manifests would be:
+A minimal example would be:
 ```bash
 jsonnet -c -J vendor -m monitoring-satellite/manifests \
---ext-str namespace="monitoring-satellite" \
---ext-str cluster_name="my-cluster" \
---ext-str alerting_enabled="false" \
---ext-str node_affinity_label='' \
---ext-str is_preview="false" \
---ext-str remote_write_enabled="false" \
---ext-str tracing_enabled="false" \
+--ext-code config="{
+    namespace: 'monitoring-satellite',
+    clusterName: 'fake-cluster',
+}" \
 monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 ```
 
@@ -75,36 +49,29 @@ monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {}
 * [Grafana](https://github.com/grafana/grafana)
 * [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics) 
 
-Monitoring-central is composed by a set of components responsible for receiving observability signals(usually from monitoring-satellite) and storing them for long term. At the same time, it provides a stable URL where one can access Grafana's UI with all datasources already configured.
+To customize the stack, we make use of Jsonnet's [external-variables feature](https://jsonnet.org/ref/stdlib.html). We expect one single external variable called `config` which is loaded and merged with monitoring-satellite to customize the stack.
 
-The monitoring-central's components can be customized by setting up different values for several Jsonnet external-variables. Some of those external variables are required (even if left empty), and other can become required depending on the values of other variables. The complete list can be seen below:
+We expect `config` to be a JSON object, where extra configuration can be added as we develop new features for monitoring-central. For more details, please check [monitoring-central data schema](docs/monitoring-central.proto).
 
-| External Variable              	| Required 	| Description                                                                  	|
-|--------------------------------	|----------	|------------------------------------------------------------------------------	|
-| namespace                      	| Yes      	| Namespace where all components will be deployed.                             	|
-| grafana_dns_name               	| Yes      	| DNS used to configure Grafanas's certificate and ingress.                    	|
-| grafana_ingress_node_port      	| Yes      	| Port used by Grafana's ingress.                                              	|
-| gcp_external_ip_address        	| Yes      	| Name of GCP static external-ip resource, used by Grafana's ingress.          	|
-| IAP_client_id                  	| Yes      	| Identity Aware Proxy client ID used to create google managed authentication. 	|
-| victoriametrics_dns_name       	| Yes      	| DNS used to configure VictoriaMetrics' certificate and ingress.              	|
-| remote_write_username          	| Yes      	| Username required to authenticate against the remote-write endpoint.         	|
-| remote_write_password          	| Yes      	| Password required to authenticate against the remote-write endpoint.         	|
-| vmauth_auth_key                	| Yes      	| Random string used to protect VictoriaMetrics' reload and debug endpoints.   	|
-| vmauth_gcp_external_ip_address 	| Yes      	| Name of GCP static external-ip resource, used by VictoriaMetrics's ingress.  	|
-
-Therefore, the simplest command that can be used to generate monitoring-central manifests would be:
+A minimal example would be:
 ```bash
 jsonnet -c -J vendor -m monitoring-central/manifests \
---ext-str namespace="monitoring-central" \
---ext-str grafana_dns_name="http://my.grafana.url" \
---ext-str grafana_ingress_node_port=32164 \
---ext-str gcp_external_ip_address="my_external_ip_address" \
---ext-str IAP_client_id="myIAP_ID" \
---ext-str IAP_client_secret="myIAP_secret" \
---ext-str victoriametrics_dns_name="http://my.victoriametrics.url" \
---ext-str vmauth_auth_key="random-key" \
---ext-str remote_write_password="password" \
---ext-str remote_write_username="user" \
---ext-str vmauth_gcp_external_ip_address="my_other_external_ip_address" \
+--ext-code config="{
+    namespace: 'monitoring-central',
+    grafana: {
+        nodePort: 32164,
+        DNS: 'http://fake.grafana.url',
+        GCPExternalIpAddress: 'fake_external_ip_address',
+        IAPClientID: 'fakeIAP_ID',
+        IAPClientSecret: 'fakeIAP_secret',
+    },
+    victoriametrics: {
+        DNS: 'http://fake.victoriametrics.url',
+        authKey: 'random-key',
+        username: 'p@ssW0rd',
+        password: 'user',
+        GCPExternalIpAddress: 'fake_external_ip_address',
+    },
+}" \
 monitoring-central/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 ```

--- a/docs/monitoring-central.proto
+++ b/docs/monitoring-central.proto
@@ -37,7 +37,7 @@ message Grafana {
 }
 
 message VictoriaMetrics {
-  // DNS where grafana will be available.
+  // DNS where VictoriaMetrics will be available.
   required string dns = 1;
 
   // Authorization key used to protect VictoriaMetrics /debug/pprof and /-/reload endpoints.

--- a/docs/monitoring-central.proto
+++ b/docs/monitoring-central.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package gitpod.monitoringCentral;
+
+message config {
+  // Namespace where monitoring-satellite is deployed to.
+  required string namespace = 1;
+
+  // Configures the Grafana deployment.
+  required Grafana grafana = 2;
+
+  // Configures the VictoriaMetrics deployment.
+  required VictoriaMetrics victoriaMetrics = 3;
+
+  // Adds a stackdriver datasource to Grafana.
+  Stackdriver stackdriver = 4;
+}
+
+message Grafana {
+  // DNS where grafana will be available.
+  required string dns = 1;
+
+  // Google's external IP resource used by Grafana's loadbalancer.
+  // See also: https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
+  required string GCPExternalIpAddress = 2;
+
+  // Google's Identity aware proxy ID used to protect Grafana.
+  // See also: https://cloud.google.com/iap/docs/concepts-overview
+  required string IAPClientID = 3;
+
+  // Google's Identity aware proxy secret used to protect Grafana.
+  // See also: https://cloud.google.com/iap/docs/concepts-overview
+  required string IAPClientSecret = 4;
+
+  // NodePort used by Grafana's loadbalancer.
+  required int32 nodePort = 5;
+}
+
+message VictoriaMetrics {
+  // DNS where grafana will be available.
+  required string dns = 1;
+
+  // Authorization key used to protect VictoriaMetrics /debug/pprof and /-/reload endpoints.
+  // See also: https://docs.victoriametrics.com/vmauth.html
+  required string authKey = 2;
+
+  // Username required to receive metrics via remote-write protocol.
+  required string username = 3;
+
+  // Password required to receive metrics via remote-write protocol.
+  required string password = 4;
+
+  // Google's external IP resource used by VictoriaMetrics's loadbalancer.
+  // See also: https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
+  required string GCPExternalIpAddress = 5;
+}
+
+message Stackdriver {
+  // Google service account's email.
+  required string clientEmail = 1;
+
+  // Default project used by the datasource.
+  required string defaultProject = 2;
+
+  // Google service account's private key.
+  required string privateKey = 3;
+}

--- a/docs/monitoring-satellite.proto
+++ b/docs/monitoring-satellite.proto
@@ -1,0 +1,97 @@
+syntax = "proto3";
+
+package gitpod.monitoringSatellite;
+
+import "k8s.io/api/core/v1/generated.proto";
+
+message config {
+  // Namespace where monitoring-satellite is deployed to.
+  required string namespace = 1;
+
+  // Configures Prometheus' `cluster` external label.
+  // All metrics will have this label attached when Prometheus
+  // pushes metrics to monitoring-central.
+  required string clusterName = 2;
+
+  // Enables alert routing to the stack
+  Alerting alerting = 3;
+
+  // Configures OpenTelemetry Collector
+  Tracing tracing = 4;
+
+  // Configures Prometheus to push metrics to a remote-write endpoint.
+  RemoteWrite remoteWrite = 5;
+
+  // Adds specific configuration to run monitoring-satellite on preview-environments.
+  PreviewEnvironment previewEnvironment = 6;
+
+  // Adds ServiceMonitors for werft deployments.
+  Werft werft = 7;
+
+  // Adds a stackdriver datasource to Grafana.
+  Stackdriver stackdriver = 8;
+
+  // Configures NodeAffinity to all components of the stack.
+  k8s.io.api.core.v1.generated.NodeAffinity nodeAffinity = 9;
+
+  // Adds specific configuration to run the stack in our CI.
+  bool continuousDelivery = 10;
+}
+
+message Alerting {
+  // Webhook URL used to route critical alerts.
+  required string slackWebhookURLCritical = 1;
+
+  // Webhook URL used to route warning alerts.
+  required string slackWebhookURLWarning = 2;
+
+  // Webhook URL used to route info alerts.
+  required string slackWebhookURLInfo = 3;
+
+  // Prefix used by the slack channels.
+  required string slackChannelPrefix = 4;
+
+  // Webhook URL used to route critical alerts. 
+  // If 'pagerdutyRoutingKey' is set, it will take precedence over 'slackWebhookURLCritical'.
+  string pagerdutyRoutingKey = 5;
+}
+
+message Tracing {
+  // API key used to push traces to Honeycomb.
+  required string honeycombAPIKey = 1;
+
+  // Which Honeycomb dataset used to push traces to.
+  required string honeycombDataset = 2;
+}
+
+message RemoteWrite {
+  // Username used to authenticate against remote-write URLs.
+  required string username = 1;
+
+  // Password used to authenticate against remote-write URLs.
+  required string password = 2;
+
+  // Remote-write URLs that monitoring-satellite pushes metrics to.
+  repeated string urls = 3;
+}
+
+message PreviewEnvironment {
+  // Port used by node-exporter to expose node metrics.
+  required int32 nodeExporterPort = 1;
+}
+
+message Werft {
+  // Namespace where werft is deployed.
+  required string namespace = 1;
+}
+
+message Stackdriver {
+  // Google service account's email.
+  required string clientEmail = 1;
+
+  // Default project used by the datasource.
+  required string defaultProject = 2;
+
+  // Google service account's private key.
+  required string privateKey = 3;
+}

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -62,8 +62,6 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
         urls: ['http://victoriametrics-vmauth.monitoring-central.svc:8427/api/v1/write'],
     },
     previewEnvironment: {
-        prometheusDNS: 'prometheus.fake.preview.io',
-        grafanaDNS: 'grafana.fake.preview.io',
         nodeExporterPort: 9100
     },
     nodeAffinity: {


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->

Adds the definition of our configuration as protobuf definitions

Aims to pass this vision that monitoring-satellite and monitoring-central act like APIs that can be customized to provide different applications.

The schema will be useful for:
* Document our apps
* Provide a validation layer for possible consumers

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #81 
