### PR TITLE
Add alerts for excessive GC of ws-daemon

### DIFF
--- a/vendor/github.com/gitpod-io/gitpod/operations/observability/mixins/workspace/rules/components/ws-daemon/alerts.libsonnet
+++ b/vendor/github.com/gitpod-io/gitpod/operations/observability/mixins/workspace/rules/components/ws-daemon/alerts.libsonnet
@@ -23,6 +23,34 @@
               increase(kube_pod_container_status_restarts_total{container="ws-daemon"}[10m]) > 0
             |||,
           },
+          {
+            alert: 'GitpodWsDaemonExcessiveGC',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              runbook_url: '',
+              summary: 'Ws-daemon is doing excessive garbage collection.',
+              description: 'Ws-daemon has excessive garbage collection time. Collecting garbage for more than 1 second.',
+            },
+            expr: |||
+              go_gc_duration_seconds{job="ws-daemon", quantile="1"} > 1
+            |||,
+          },
+          {
+            alert: 'GitpodWsDaemonExcessiveGC',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              runbook_url: '',
+              summary: 'Ws-daemon is doing excessive garbage collection.',
+              description: 'Ws-daemon has excessive garbage collection time. Collecting garbage for more than 1 minute.',
+            },
+            expr: |||
+              go_gc_duration_seconds{job="ws-daemon", quantile="1"} > 60
+            |||,
+          },
         ],
       },
     ],


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add alerts for ws-daemon excessive GC.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->


## How to test
<!-- Provide steps to test this PR -->
NA

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add alerts if the GC of ws-daemon is excessive
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
We need to update the runbooks with steps to mitigate this issue. The discussion whether to restart ws-daemon is still happening in the original issue https://github.com/gitpod-io/gitpod/issues/7485
