### PR TITLE
config: Make it possible to override Prometheus' resources limits/requests

### DIFF
--- a/docs/monitoring-satellite.proto
+++ b/docs/monitoring-satellite.proto
@@ -36,6 +36,9 @@ message config {
 
   // Adds specific configuration to run the stack in our CI.
   bool continuousDelivery = 10;
+
+  // Specific configuration to override Prometheus Custom Resource
+  Prometheus prometheus = 11;
 }
 
 message Alerting {
@@ -94,4 +97,9 @@ message Stackdriver {
 
   // Google service account's private key.
   required string privateKey = 3;
+}
+
+message Prometheus {
+  // Overrides the 'resources' field in Prometheus spec
+  k8s.io.api.core.v1.generated.ResourceRequirements resources = 1;
 }

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -83,6 +83,12 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
   key
 |||,
     },
+    prometheus: {
+        resources: {
+            limits: { cpu: '10m' },
+            requests: { memory: '200Mi' },
+        },
+    },
 }" \
 monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 

--- a/monitoring-satellite/monitoring-satellite.libsonnet
+++ b/monitoring-satellite/monitoring-satellite.libsonnet
@@ -47,8 +47,34 @@ local gitpod = import '../components/gitpod/gitpod.libsonnet';
         cluster: config.clusterName,
       },
       resources: {
-        requests: { memory: '2Gi', cpu: '1000m' },
-        limits: { memory: '10Gi', cpu: '3000m' },
+        requests: {
+          memory: if std.objectHas(config, 'prometheus') &&
+                     std.objectHas(config.prometheus, 'resources') &&
+                     std.objectHas(config.prometheus.resources, 'requests') &&
+                     std.objectHas(config.prometheus.resources.requests, 'memory')
+          then config.prometheus.resources.requests.memory
+          else '2Gi',
+          cpu: if std.objectHas(config, 'prometheus') &&
+                  std.objectHas(config.prometheus, 'resources') &&
+                  std.objectHas(config.prometheus.resources, 'requests') &&
+                  std.objectHas(config.prometheus.resources.requests, 'cpu')
+          then config.prometheus.resources.requests.cpu
+          else '1000m',
+        },
+        limits: {
+          memory: if std.objectHas(config, 'prometheus') &&
+                     std.objectHas(config.prometheus, 'resources') &&
+                     std.objectHas(config.prometheus.resources, 'limits') &&
+                     std.objectHas(config.prometheus.resources.limits, 'memory')
+          then config.prometheus.resources.limits.memory
+          else '10Gi',
+          cpu: if std.objectHas(config, 'prometheus') &&
+                  std.objectHas(config.prometheus, 'resources') &&
+                  std.objectHas(config.prometheus.resources, 'limits') &&
+                  std.objectHas(config.prometheus.resources.limits, 'cpu')
+          then config.prometheus.resources.limits.cpu
+          else '3000m',
+        },
       },
     },
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Title self-explanatory.

_PS: This can be super simpler on the next release of jsonnet_
![image](https://user-images.githubusercontent.com/24193764/154499913-b1dd3d54-7f73-4558-b485-df7f51110bb8.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/1208

## How to test
<!-- Provide steps to test this PR -->
Play around with `hack/generate.sh`, setting different values will generate different values under `manifests/prometheus/prometheus.yaml`.
