### PR TITLE
Add addon that removes Node-exporter priority-class

### DIFF
--- a/addons/strip-priority-class.libsonnet
+++ b/addons/strip-priority-class.libsonnet
@@ -1,0 +1,13 @@
+{
+  nodeExporter+: {
+    daemonset+: {
+      spec+: {
+        template+: {
+          spec+: {
+            priorityClassName:: null
+          },
+        },
+      },
+    },
+  },
+}

--- a/monitoring-satellite/monitoring-satellite.libsonnet
+++ b/monitoring-satellite/monitoring-satellite.libsonnet
@@ -10,6 +10,7 @@ local gitpod = import '../components/gitpod/gitpod.libsonnet';
 (import '../addons/ksm-extra-labels.libsonnet') +
 (import '../addons/metrics-relabeling.libsonnet') +
 (import '../addons/argocd-crd-replace.libsonnet') +
+(import '../addons/strip-priority-class.libsonnet') +
 (if std.objectHas(config, 'alerting') then (import '../addons/alerting.libsonnet')(config) else {}) +
 (if std.objectHas(config, 'remoteWrite') then (import '../addons/remote-write.libsonnet')(config) else {}) +
 (if std.objectHas(config, 'tracing') then (import '../addons/tracing.libsonnet')(config) else {}) +


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Node-exporter got categorized as a node-critical pod, to prevent affinity/scheduling issues and make sure node-exporter is always running. ([Ref](https://github.com/prometheus-operator/kube-prometheus/pull/1649)).

We haven't studied what changes we need to make to have it working for us, and rolling out doesn't work out of the box:

![image](https://user-images.githubusercontent.com/24193764/154997917-2f4157f0-8269-4f58-b5c0-844709dbddaf.png)

This PR just removes that configuration until we make the necessary changes to have it