### PR TITLE
addons/kubescape: Make scrape interval configurable

### DIFF
--- a/addons/kubescape.libsonnet
+++ b/addons/kubescape.libsonnet
@@ -4,6 +4,10 @@ function(config) {
   values+:: {
     kubescapeParams: {
       namespace: config.namespace,
+      scrapeInterval:
+        if std.objectHas(config.kubescape, 'scrapeInterval')
+        then config.kubescape.scrapeInterval
+        else '240s',
     },
 
     grafana+: {

--- a/docs/monitoring-satellite.proto
+++ b/docs/monitoring-satellite.proto
@@ -110,5 +110,6 @@ message Prometheus {
 }
 
 message Kubescape {
-  
+  // Interval between scrapes performed by Prometheus.
+  string scrapeInterval = 1;
 }


### PR DESCRIPTION
We want to have smaller scrape intervals, but Kubescape can't handle scraping big cluster at the moment. This change makes it possible to set bigger scrape interval for such use-cases