### PR TITLE
Momentarily disable networkpolicie

### DIFF
--- a/addons/networkpolicies-disabled.libsonnet
+++ b/addons/networkpolicies-disabled.libsonnet
@@ -1,0 +1,37 @@
+// FIXME(arthursens):
+// This addon should be removed after https://github.com/prometheus-operator/kube-prometheus/pull/1724 is merged
+
+// Disables creation of NetworkPolicies
+{
+  blackboxExporter+: {
+    networkPolicy:: {},
+  },
+
+  kubeStateMetrics+: {
+    networkPolicy:: {},
+  },
+
+  nodeExporter+: {
+    networkPolicy:: {},
+  },
+
+  prometheusAdapter+: {
+    networkPolicy:: {},
+  },
+
+  alertmanager+: {
+    networkPolicy:: {},
+  },
+
+  grafana+: {
+    networkPolicy:: {},
+  },
+
+  prometheus+: {
+    networkPolicy:: {},
+  },
+
+  prometheusOperator+: {
+    networkPolicy:: {},
+  },
+}

--- a/monitoring-central/monitoring-central.libsonnet
+++ b/monitoring-central/monitoring-central.libsonnet
@@ -8,6 +8,7 @@ local kubePrometheus =
   (import 'kube-prometheus/main.libsonnet') +
   (import 'kube-prometheus/platforms/gke.libsonnet') +
   (import 'kube-prometheus/addons/podsecuritypolicies.libsonnet') +
+  (import '../addons/networkpolicies-disabled.libsonnet') +
   (import '../addons/disable-grafana-auth.libsonnet') +
   (import '../addons/grafana-on-gcp-oauth.libsonnet')(config) +
   {


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Kube-prometheus with NetworkPolicies currently isn't working well with setups that use ingresses, this PR disables network policies until the bug is fixed upstream
