### PR TITLE
Add Pyrra to monitoring-satellite as an optional component

### DIFF
--- a/addons/pyrra.libsonnet
+++ b/addons/pyrra.libsonnet
@@ -1,0 +1,1 @@
+function(params) (import 'kube-prometheus/addons/pyrra.libsonnet') 

--- a/docs/monitoring-satellite.proto
+++ b/docs/monitoring-satellite.proto
@@ -43,6 +43,9 @@ message config {
 
   // Specific configuration to override Kubescape configuration
   Kubescape kubescape = 12;
+
+  // Specific configuration to override Pyrra configuration
+  Pyrra pyrra = 13;
 }
 
 message Alerting {
@@ -112,4 +115,8 @@ message Prometheus {
 message Kubescape {
   // Interval between scrapes performed by Prometheus.
   string scrapeInterval = 1;
+}
+
+message Pyrra {
+
 }

--- a/hack/deploy-satellite.sh
+++ b/hack/deploy-satellite.sh
@@ -34,6 +34,7 @@ done
 until kubectl $KUBECONFIG_FLAG get servicemonitors.monitoring.coreos.com --all-namespaces ; do date; sleep 1; echo ""; done
 until kubectl $KUBECONFIG_FLAG get prometheusrules.monitoring.coreos.com --all-namespaces ; do date; sleep 1; echo ""; done
 
+kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/pyrra/crd.yaml
 
 for operatorManifest in $(find monitoring-satellite/manifests/prometheusOperator/ -type f ! -name "*CustomResourceDefinition.yaml"); 
 do 
@@ -48,3 +49,4 @@ kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/kubescape/
 kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/grafana/
 kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/alertmanager/
 kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/otelCollector/
+kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/pyrra/

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -30,6 +30,7 @@ if [[ $environment == "CI" ]]; then
         honeycombDataset: 'fake-dataset',
       },
       kubescape: {},
+      pyrra: {},
       continuousIntegration: true,
     }" \
     monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
@@ -85,6 +86,7 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
 |||,
     },
     kubescape: {},
+    pyrra: {},
 }" \
 monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 

--- a/monitoring-satellite/monitoring-satellite.libsonnet
+++ b/monitoring-satellite/monitoring-satellite.libsonnet
@@ -11,12 +11,14 @@ local gitpod = import '../components/gitpod/gitpod.libsonnet';
 (import '../addons/metrics-relabeling.libsonnet') +
 (import '../addons/argocd-crd-replace.libsonnet') +
 (import '../addons/strip-priority-class.libsonnet') +
+(import '../addons/networkpolicies-disabled.libsonnet') +
 (if std.objectHas(config, 'alerting') then (import '../addons/alerting.libsonnet')(config) else {}) +
 (if std.objectHas(config, 'remoteWrite') then (import '../addons/remote-write.libsonnet')(config) else {}) +
 (if std.objectHas(config, 'tracing') then (import '../addons/tracing.libsonnet')(config) else {}) +
 (if std.objectHas(config, 'werft') then (import '../addons/monitor-werft.libsonnet')(config) else {}) +
 (if std.objectHas(config, 'stackdriver') then (import '../addons/grafana-stackdriver-datasource.libsonnet')(config) else {}) +
 (if std.objectHas(config, 'kubescape') then (import '../addons/kubescape.libsonnet')(config) else {}) +
+(if std.objectHas(config, 'pyrra') then (import '../addons/pyrra.libsonnet')(config) else {}) +
 {
   values+:: {
     common+: {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
WebApp's public API is going to introduce some good engineering practices around observability. They want a component that can help with the creation of SLOs.

Kube-prometheus already has such a component, this PR just adds it when desired.