### PR TITLE
Remove GitpodWsDaemonExcessiveGC critical alert

### DIFF
--- a/vendor/github.com/gitpod-io/gitpod/operations/observability/mixins/workspace/rules/components/ws-daemon/alerts.libsonnet
+++ b/vendor/github.com/gitpod-io/gitpod/operations/observability/mixins/workspace/rules/components/ws-daemon/alerts.libsonnet
@@ -29,20 +29,6 @@
               severity: 'warning',
             },
             annotations: {
-              runbook_url: '',
-              summary: 'Ws-daemon is doing excessive garbage collection.',
-              description: 'Ws-daemon has excessive garbage collection time. Collecting garbage for more than 1 second.',
-            },
-            expr: |||
-              go_gc_duration_seconds{job="ws-daemon", quantile="1"} > 1
-            |||,
-          },
-          {
-            alert: 'GitpodWsDaemonExcessiveGC',
-            labels: {
-              severity: 'critical',
-            },
-            annotations: {
               runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWsDaemonExcessiveGC.md',
               summary: 'Ws-daemon is doing excessive garbage collection.',
               description: 'Ws-daemon has excessive garbage collection time. Collecting garbage for more than 1 minute.',


### PR DESCRIPTION
## Description

ws-daemon is a statetul component. High GC times could be triggered by simultaneous backups/restoration and should not be considered an error. Any action, like a restart, could lead to the loss of user data.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Remove GitpodWsDaemonExcessiveGC critical alert
```
