### PR TITLE
Remove restricted psp from mon-central

### DIFF
--- a/monitoring-central/main.jsonnet
+++ b/monitoring-central/main.jsonnet
@@ -3,7 +3,6 @@ local monitoringCentral = (import './monitoring-central.libsonnet');
 
 [
   monitoringCentral.kubePrometheus.namespace,
-  monitoringCentral.restrictedPodSecurityPolicy,
 ] +
 [monitoringCentral.grafana[name] for name in std.objectFields(monitoringCentral.grafana)] +
 [monitoringCentral.victoriametrics[name] for name in std.objectFields(monitoringCentral.victoriametrics)]

--- a/monitoring-central/manifests/yaml-generator.jsonnet
+++ b/monitoring-central/manifests/yaml-generator.jsonnet
@@ -2,6 +2,5 @@
 local monitoringCentral = (import '../monitoring-central.libsonnet');
 
 { namespace: monitoringCentral.kubePrometheus.namespace } +
-{ 'podsecuritypolicy-restricted': monitoringCentral.restrictedPodSecurityPolicy } +
 { ['grafana/' + name]: monitoringCentral.grafana[name] for name in std.objectFields(monitoringCentral.grafana) } +
 { ['victoriametrics/' + name]: monitoringCentral.victoriametrics[name] for name in std.objectFields(monitoringCentral.victoriametrics) }


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/ops/issues/2465 by removing the PodSecurityPolicy from monitoring-central.

This is safe to do as long as we always have monitoring-satellite running in the same cluster as monitoring-central