### PR TITLE
Add Platform mixin to Monitoring-central

### DIFF
--- a/components/gitpod/gitpod.libsonnet
+++ b/components/gitpod/gitpod.libsonnet
@@ -48,7 +48,12 @@ function(params) {
       g._config.mixin._config,
   },
 
-  mixin:: $.crossTeamsMixin + $.ideMixin + $.webappMixin + $.workspaceMixin + $.selfhostedMixin,
+  platformMixin:: (import 'gitpod/platform/mixin.libsonnet') {
+    _config+::
+      g._config.mixin._config,
+  },
+
+  mixin:: $.crossTeamsMixin + $.ideMixin + $.webappMixin + $.workspaceMixin + $.selfhostedMixin + $.platformMixin,
 
   prometheusRule: {
     apiVersion: 'monitoring.coreos.com/v1',

--- a/monitoring-central/monitoring-central.libsonnet
+++ b/monitoring-central/monitoring-central.libsonnet
@@ -64,7 +64,7 @@ local kubePrometheus =
         },
         dashboards:: {},
         folderDashboards+:: {
-          'Team Platform': $.kubernetesControlPlane.mixin.grafanaDashboards + $.prometheus.mixin.grafanaDashboards + $.alertmanager.mixin.grafanaDashboards + $.certmanager.mixin.grafanaDashboards + $.nodeExporter.mixin.grafanaDashboards + $.kubescape.mixin.grafanaDashboards,
+          'Team Platform': $.kubernetesControlPlane.mixin.grafanaDashboards + $.prometheus.mixin.grafanaDashboards + $.alertmanager.mixin.grafanaDashboards + $.certmanager.mixin.grafanaDashboards + $.nodeExporter.mixin.grafanaDashboards + $.kubescape.mixin.grafanaDashboards + $.gitpod.platformMixin.grafanaDashboards,
           'Cross Teams': $.gitpod.crossTeamsMixin.grafanaDashboards,
           'Team IDE': $.gitpod.ideMixin.grafanaDashboards,
           'Team WebApp': $.gitpod.webappMixin.grafanaDashboards,


### PR DESCRIPTION
Following https://github.com/gitpod-io/gitpod/pull/10482, this PR adds the newly created platform mixin to monitoring-central, making sure [this dashboard](https://grafana.gitpod.io/d/V1Qq_IBM_za0/preview-environments?orgId=1&from=now-6h&to=now&var-datasource=VictoriaMetrics&var-cluster=harvester&var-node=All&refresh=30s) is deployed with ArgoCD