### PR TITLE
Add probes to monitoring-satellite

### DIFF
--- a/addons/probers.libsonnet
+++ b/addons/probers.libsonnet
@@ -1,0 +1,23 @@
+local probers = import '../components/probers/probers.libsonnet';
+
+function(config) {
+
+  assert std.objectHas(config.probe, 'targets') : (
+    "If 'probe' is set, 'targets' should be declared"
+  ),
+
+  assert std.isArray(config.probe.targets) : (
+    'remote-write targets should be an array'
+  ),
+
+  values+:: {
+    probeParams: {
+      namespace: config.namespace,
+      blackboxExporterName: 'blackbox-exporter',
+      blackboxExporterNamespace: config.namespace,
+      targets: config.probe.targets,
+    },
+  },
+
+  probers: probers($.values.probeParams),
+}

--- a/components/probers/probers.libsonnet
+++ b/components/probers/probers.libsonnet
@@ -1,0 +1,44 @@
+local config = std.extVar('config');
+local defaults = {
+  defaults: self,
+  name: 'blackbox-exporter',
+  namespace: error 'must provide namespace',
+  commonLabels: {
+    'app.kubernetes.io/name': defaults.name,
+    'app.kubernetes.io/part-of': 'kube-prometheus',
+  },
+  blackboxExporterName: error 'must provide blackbox-exporter name',
+  blackboxExporterNamespace: error 'must provide blackbox-exporter namespace',
+  targets: error 'must provide targets',
+};
+
+function(params) {
+  local prober = self,
+  _config:: defaults + params,
+
+
+  probe: {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'Probe',
+    metadata: {
+      name: prober._config.name,
+      namespace: prober._config.namespace,
+      labels: prober._config.commonLabels,
+    },
+    spec: {
+      jobName: 'probe',
+      prober: {
+        url: prober._config.blackboxExporterName + '.' + prober._config.blackboxExporterNamespace + '.svc:19115',
+        scheme: 'http',
+        path: '/probe',
+      },
+      interval: '30s',
+      module: 'http_2xx',
+      targets: {
+        staticConfig: {
+          static: prober._config.targets,
+        },
+      },
+    },
+  },
+}

--- a/hack/deploy-satellite.sh
+++ b/hack/deploy-satellite.sh
@@ -50,3 +50,5 @@ kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/grafana/
 kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/alertmanager/
 kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/otelCollector/
 kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/pyrra/
+kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/blackboxExporter/
+kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/probers/

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -31,6 +31,9 @@ if [[ $environment == "CI" ]]; then
       },
       kubescape: {},
       pyrra: {},
+      probe: {
+        targets: ['http://google.com'],
+      },
       continuousIntegration: true,
     }" \
     monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
@@ -87,6 +90,9 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
     },
     kubescape: {},
     pyrra: {},
+    probe: {
+        targets: ['http://google.com'],
+    },
 }" \
 monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 

--- a/monitoring-satellite/main.jsonnet
+++ b/monitoring-satellite/main.jsonnet
@@ -1,7 +1,6 @@
 // This file is used to update monitoring-satellites with ArgoCD
 local monitoringSatellite = (import './monitoring-satellite.libsonnet');
 local excludedComponents = [
-  'blackboxExporter',
   'kubePrometheus',
   'restrictedPodSecurityPolicy',
 ];

--- a/monitoring-satellite/manifests/yaml-generator.jsonnet
+++ b/monitoring-satellite/manifests/yaml-generator.jsonnet
@@ -1,7 +1,6 @@
 // This file is used to generate YAMLs for testing purposes.
 local monitoringSatellite = (import '../monitoring-satellite.libsonnet');
 local excludedComponents = [
-  'blackboxExporter',
   'kubePrometheus',
   'restrictedPodSecurityPolicy',
 ];

--- a/monitoring-satellite/monitoring-satellite.libsonnet
+++ b/monitoring-satellite/monitoring-satellite.libsonnet
@@ -19,6 +19,7 @@ local gitpod = import '../components/gitpod/gitpod.libsonnet';
 (if std.objectHas(config, 'stackdriver') then (import '../addons/grafana-stackdriver-datasource.libsonnet')(config) else {}) +
 (if std.objectHas(config, 'kubescape') then (import '../addons/kubescape.libsonnet')(config) else {}) +
 (if std.objectHas(config, 'pyrra') then (import '../addons/pyrra.libsonnet')(config) else {}) +
+(if std.objectHas(config, 'probe') then (import '../addons/probers.libsonnet')(config) else {}) +
 {
   values+:: {
     common+: {

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -48,7 +48,7 @@ func testMain(m *testing.M) int {
 func TestDeployments(t *testing.T) {
 	kClient := promClient.kubeClient
 
-	apps := []string{"grafana", "kube-state-metrics", "prometheus-operator", "otel-collector", "kubescape"}
+	apps := []string{"grafana", "kube-state-metrics", "prometheus-operator", "otel-collector", "kubescape", "blackbox-exporter"}
 
 	for _, app := range apps {
 		// Table-driven + parallel tests are quite tricky and require us


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds the ability to use monitoring-satellite to do monitoring via probing.

It is an opt-in component, and you have the ability to set multiple probe targets with the following addition to your `config` object:

```jsonnet
config: {
  probe: {
    targets: ['http://target1.com', 'http://target2.com']
  }
}
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/2733


## How to test

* You can generate all the YAML files by running `make generate`.
* Run `make deploy-satellite` to deploy a KinD cluster with monitoring-satellite running on it.
* Expose the Prometheus UI with `kubectl port-forward -n monitoring-satellite prometheus-k8s-0 9090`
* You should be able to query metrics that has the prefix `probe_*`, those are metrics from blackbox-exporter