### PR TITLE
Add possibility to add multiple external labels to Prometheus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,11 @@ deploy-satellite: generate
 	./hack/prepare-kind.sh
 	./hack/deploy-satellite.sh
 
+.PHONY: deploy-central
+deploy-central: generate
+	./hack/prepare-kind.sh
+	./hack/deploy-central.sh
+
 .PHONY: test-e2e
 test-e2e:
 	@cd tests/e2e && go test -timeout 55m -v . -count=1

--- a/hack/deploy-central.sh
+++ b/hack/deploy-central.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+KUBECONFIG=""
+KUBECONFIG_FLAG=""
+
+opts=$(getopt \
+  --longoptions "kubeconfig:" \
+  --name "$(basename "$0")" \
+  --options "" \
+  -- "$@"
+)
+
+eval set -- "$opts"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --kubeconfig) KUBECONFIG=$2 ; shift 2 ;;
+    *) break ;;
+  esac
+done
+
+if [[ $KUBECONFIG != "" ]]; then
+  KUBECONFIG_FLAG="--kubeconfig ${KUBECONFIG}"
+fi
+
+kubectl $KUBECONFIG_FLAG apply -f monitoring-central/manifests/namespace.yaml
+kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/podsecuritypolicy-restricted.yaml
+
+kubectl $KUBECONFIG_FLAG apply -f monitoring-central/manifests/grafana/
+kubectl $KUBECONFIG_FLAG apply -f monitoring-central/manifests/victoriametrics/

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -61,6 +61,12 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
         honeycombAPIKey: 'fake-key',
         honeycombDataset: 'fake-dataset',
     },
+    prometheus: {
+        externalLabels: {
+            environment: 'test',
+            'extra-label': 'extra-label-value',
+        },
+    },
     remoteWrite: {
         username: 'user',
         password: 'p@ssW0rd',

--- a/monitoring-satellite/monitoring-satellite.libsonnet
+++ b/monitoring-satellite/monitoring-satellite.libsonnet
@@ -48,9 +48,8 @@ local gitpod = import '../components/gitpod/gitpod.libsonnet';
     prometheus+: {
       replicas: 1,
       namespaces+: [$.values.certmanagerParams.certmanagerNamespace],
-      externalLabels: {
-        cluster: config.clusterName,
-      },
+      externalLabels: (if std.objectHas(config, 'clusterName') then { cluster: config.clusterName } else {}) +
+                      (if std.objectHas(config, 'prometheus') && std.objectHas(config.prometheus, 'externalLabels') then config.prometheus.externalLabels else {}),
       resources: {
         requests: {
           memory: if std.objectHas(config, 'prometheus') &&


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds the possibility of adding multiple external labels to Prometheus, while being backward compatible with the current configuration to set the `cluster` label.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/2770

## How to test
<!-- Provide steps to test this PR -->
* Run `make deploy-satellite`, to spin up a KinD cluster with monitoring satellite in it.
* Run `kubectl describe prometheus -n monitoring-satellite k8s`
* You'll notice that all external labels added to `generate.sh` are present, the ones added via `config.prometheus.externalLabels` and also `config.clusterName` for backward compatibilities

