### PR TITLE
Enable configuring Prometheus feature-flags

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -66,6 +66,7 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
             environment: 'test',
             'extra-label': 'extra-label-value',
         },
+        enableFeatures: ['remote-write-receiver'],
     },
     remoteWrite: {
         username: 'user',

--- a/monitoring-satellite/monitoring-satellite.libsonnet
+++ b/monitoring-satellite/monitoring-satellite.libsonnet
@@ -48,6 +48,7 @@ local gitpod = import '../components/gitpod/gitpod.libsonnet';
     prometheus+: {
       replicas: 1,
       namespaces+: [$.values.certmanagerParams.certmanagerNamespace],
+      enableFeatures: (if std.objectHas(config, 'prometheus') && std.objectHas(config.prometheus, 'enableFeatures') then config.prometheus.enableFeatures else []),
       externalLabels: (if std.objectHas(config, 'clusterName') then { cluster: config.clusterName } else {}) +
                       (if std.objectHas(config, 'prometheus') && std.objectHas(config.prometheus, 'externalLabels') then config.prometheus.externalLabels else {}),
       resources: {


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
This PR adds the possibility to configure the field `enableFeatures` in the Prometheus CRD.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/2791

## How to test
<!-- Provide steps to test this PR -->
* Play around with the script `hack/generate.sh`
* Run `make generate` to regenerate YAML manifests
* Notice that the file `monitoring-satellite/manifests/prometheus/prometheus.yml` has the field `enableFeatures` as expected