### PR TITLE
Enable metric_relabeling during remote-write

### DIFF
--- a/addons/remote-write.libsonnet
+++ b/addons/remote-write.libsonnet
@@ -17,6 +17,13 @@ function(config) {
         remoteWrite+: [
           {
             url: url,
+            writeRelabelConfigs: (
+              if std.objectHas(config.remoteWrite, 'writeRelabelConfigs') then
+                assert std.isArray(config.remoteWrite.writeRelabelConfigs) : ('Remote write relabeling configs should be an array.');
+
+                config.remoteWrite.writeRelabelConfigs
+              else []
+            ),
             basicAuth: {
               username: {
                 name: 'remote-write-auth',

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -64,13 +64,21 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
     prometheus: {
         externalLabels: {
             environment: 'test',
-            'extra-label': 'extra-label-value',
         },
     },
     remoteWrite: {
         username: 'user',
         password: 'p@ssW0rd',
-        urls: ['http://victoriametrics-vmauth.monitoring-central.svc:8427/api/v1/write'],
+        urls: ['http://victoriametrics.monitoring-central.svc:8480/insert/0/prometheus'],
+        writeRelabelConfigs: [
+          {
+            sourceLabels: ['__name__'],
+            targetLabel: '__name__',
+            regex: 'up',
+            action: 'replace',
+            replacement: 'relabeled_up'
+          }
+        ],
     },
     previewEnvironment: {
         nodeExporterPort: 9100


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Adds the possibility to configure metrics relabeling during remote-write. This will be used to filter all unnecessary metrics from preview environments when remote-writing to core-dev

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/2763

## How to test
<!-- Provide steps to test this PR -->
* Run `make deploy-satellite && make deploy-central` to spin up a KinD cluster with both monitoring-satellite and monitoring-central installed
* You'll notice that in prometheus logs that there are some networking problems between prometheus -> victoriametrics, BUT you won't see any relabeling errors!! 😅 