### PR TITLE
Remove duplicated node-port

### DIFF
--- a/addons/remote-write-ingress.libsonnet
+++ b/addons/remote-write-ingress.libsonnet
@@ -44,9 +44,12 @@ function(config) {
       spec+: {
         type: 'NodePort',
         ports: std.map(
-          function(p) p {
-            nodePort: config.prometheus.nodePort,
-          }
+          function(p)
+            if p.name == 'web' then
+              p {
+                nodePort: config.prometheus.nodePort,
+              }
+            else p
           , super.ports
         ),
       },


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
In https://github.com/gitpod-io/observability/pull/144 we introduced an ingress for Prometheus, but accidentally broke it in the process.

The problem is that Prometheus' service has 2 ports, and we wanted to add a NodePort to only 1
