### PR TITLE
Raise the alert level of KubeNodeNotReady to critical

### DIFF
--- a/lib/alert-severity-mapper.libsonnet
+++ b/lib/alert-severity-mapper.libsonnet
@@ -4,6 +4,7 @@ local alertSeverityMap = {
   // Critical alerts
   // Map alerts as 'critical' if it indicates a problem that requires human intervention immediately.
   NodeFilesystemAlmostOutOfSpace: 'critical',
+  KubeNodeNotReady: 'critical',
 
   // Warning alerts
   // Map alerts as 'warning' if it indicates a problem that needs human intervention, but it can wait until the next shift.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Raise the alert level of KubeNodeNotReady to critical

There are times when the node will enter not ready mode, possibly due to full disks or high IO causing network traffic blocking, and we need the prometheus alert to help us find it in time

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10883

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
