### PR TITLE
Directly use base64 enconded secrets for ingress

### DIFF
--- a/addons/remote-write-ingress.libsonnet
+++ b/addons/remote-write-ingress.libsonnet
@@ -4,7 +4,7 @@ function(config) {
   assert std.objectHas(config.prometheus, 'nodePort') : 'prometheus.nodePort required',
   assert std.isNumber(config.prometheus.nodePort) : 'prometheus.nodePort should be a number',
   assert std.objectHas(config.prometheus, 'GCPExternalIpAddress') : 'prometheus.GCPExternalIpAddress required',
-  assert std.objectHas(config.prometheus, 'BasicAuthSecret') : 'prometheus.BasicAuthSecret required',
+  assert std.objectHas(config.prometheus, 'BasicAuthSecretBase64') : 'prometheus.BasicAuthSecretBase64 required',
 
 
   prometheus+: {
@@ -36,7 +36,7 @@ function(config) {
         labels: $.prometheus.service.metadata.labels,
       },
       data: {
-        auth: std.base64(config.prometheus.BasicAuthSecret),
+        auth: config.prometheus.BasicAuthSecretBase64,
       },
     },
 

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -79,7 +79,7 @@ jsonnet -c -J vendor -m monitoring-satellite/manifests \
         DNS: 'prometheus.fake.dns.com',
         nodePort: 32164,
         GCPExternalIpAddress: 'external-ip-name',
-        BasicAuthSecret: '4b9d9f94715581fed0c7:$apr1$t7yWb1qu$1OgkmI30xEnR4tbAI0hQy0',
+        BasicAuthSecretBase64: 'NGI5ZDlmOTQ3MTU1ODFmZWQwYzc6JGFwcjEkdDd5V2IxcXUkMU9na21JMzB4RW5SNHRiQUkwaFF5MA==',
         enableFeatures: ['remote-write-receiver'],
     },
     remoteWrite: {


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
When generating the ingress secrets, we're getting a lot of bumps with scaping special characters in ArgoCD+Jsonnet.

This PR changes the variable to use base64 encoded directly, so we don't need to handle special characters at all
