### PR TITLE
Use strong SSL policy for central's Grafana

### DIFF
--- a/addons/grafana-on-gcp-oauth.libsonnet
+++ b/addons/grafana-on-gcp-oauth.libsonnet
@@ -53,6 +53,7 @@ function(config) {
           'kubernetes.io/ingress.global-static-ip-name': config.grafana.GCPExternalIpAddress,
           'kubernetes.io/ingress.class': 'gce',
           'cert-manager.io/cluster-issuer': $.grafana.certificate.spec.issuerRef.name,
+          'networking.gke.io/v1beta1.FrontendConfig': $.grafana.frontendConfig.metadata.name,
         },
         labels: $.grafana.service.metadata.labels,
         name: 'grafana',
@@ -108,6 +109,22 @@ function(config) {
           oauthclientCredentials: {
             secretName: $.grafana.backendOAuthSecret.metadata.name,
           },
+        },
+      },
+    },
+
+    frontendConfig: {
+      apiVersion: 'networking.gke.io/v1beta1',
+      kind: 'FrontendConfig',
+      metadata: {
+        name: 'grafana',
+        namespace: config.namespace,
+      },
+      spec: {
+        sslPolicy: 'grafana-ssl-policy',
+        redirectToHttps: {
+          enabled: true,
+          responseCodeName: '301',
         },
       },
     },


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Configures monitoring-central to use the SSL policy created at https://github.com/gitpod-io/ops/pull/2966

Fixes https://github.com/gitpod-io/security/issues/36