### PR TITLE
tests: Increase timeout for scraping deployments

### DIFF
--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -57,7 +57,7 @@ func TestDeployments(t *testing.T) {
 		app := app
 		t.Run(app, func(t *testing.T) {
 			t.Parallel()
-			err := wait.Poll(15*time.Second, 5*time.Minute, func() (bool, error) {
+			err := wait.Poll(15*time.Second, 10*time.Minute, func() (bool, error) {
 				deployment, err := kClient.AppsV1().Deployments("monitoring-satellite").Get(context.Background(), app, metav1.GetOptions{})
 				if err != nil {
 					t.Logf("%v deployment not ready", app)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Kubespace is configured to be scrapped once every 240 seconds since it causes a heavy load onto the clusters. This also causes unpredictable behavior where it can take up to 479 seconds for its first scrape.

This PR increases the test timeout to remove the flakiness cause by said unpredictability


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #109

