### PR TITLE
Add Pyrra to monitoring-central and disable default SLOs

### DIFF
--- a/addons/pyrra.libsonnet
+++ b/addons/pyrra.libsonnet
@@ -1,1 +1,19 @@
-function(params) (import 'kube-prometheus/addons/pyrra.libsonnet')
+function(params) (import 'kube-prometheus/addons/pyrra.libsonnet') {
+
+  pyrra+: {
+    'slo-apiserver-read-response-errors':: {},
+    'slo-apiserver-write-response-errors':: {},
+    'slo-apiserver-read-resource-latency':: {},
+    'slo-apiserver-read-namespace-latency':: {},
+    'slo-apiserver-read-cluster-latency':: {},
+    'slo-kubelet-request-errors':: {},
+    'slo-kubelet-runtime-errors':: {},
+    'slo-coredns-response-errors':: {},
+    'slo-prometheus-operator-reconcile-errors':: {},
+    'slo-prometheus-operator-http-errors':: {},
+    'slo-prometheus-rule-evaluation-failures':: {},
+    'slo-prometheus-sd-kubernetes-errors':: {},
+    'slo-prometheus-query-errors':: {},
+    'slo-prometheus-notification-errors':: {},
+  },
+}

--- a/hack/deploy-central.sh
+++ b/hack/deploy-central.sh
@@ -23,8 +23,11 @@ if [[ $KUBECONFIG != "" ]]; then
   KUBECONFIG_FLAG="--kubeconfig ${KUBECONFIG}"
 fi
 
+kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/pyrra/crd.yaml
+
 kubectl $KUBECONFIG_FLAG apply -f monitoring-central/manifests/namespace.yaml
 kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/podsecuritypolicy-restricted.yaml
 
 kubectl $KUBECONFIG_FLAG apply -f monitoring-central/manifests/grafana/
 kubectl $KUBECONFIG_FLAG apply -f monitoring-central/manifests/victoriametrics/
+kubectl $KUBECONFIG_FLAG apply -f monitoring-central/manifests/pyrra/

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -154,7 +154,9 @@ jsonnet -c -J vendor -m monitoring-central/manifests \
   key
 |||,
     },
-    pyrra: {},
+    pyrra: {
+        prometheusURL: 'http://victoriametrics.monitoring-central.svc.cluster.local:8428'
+    },
 }" \
 monitoring-central/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -154,6 +154,7 @@ jsonnet -c -J vendor -m monitoring-central/manifests \
   key
 |||,
     },
+    pyrra: {},
 }" \
 monitoring-central/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 

--- a/monitoring-central/manifests/yaml-generator.jsonnet
+++ b/monitoring-central/manifests/yaml-generator.jsonnet
@@ -3,4 +3,5 @@ local monitoringCentral = (import '../monitoring-central.libsonnet');
 
 { namespace: monitoringCentral.kubePrometheus.namespace } +
 { ['grafana/' + name]: monitoringCentral.grafana[name] for name in std.objectFields(monitoringCentral.grafana) } +
-{ ['victoriametrics/' + name]: monitoringCentral.victoriametrics[name] for name in std.objectFields(monitoringCentral.victoriametrics) }
+{ ['victoriametrics/' + name]: monitoringCentral.victoriametrics[name] for name in std.objectFields(monitoringCentral.victoriametrics) } +
+{ ['pyrra/' + name]: monitoringCentral.pyrra[name] for name in std.objectFields(monitoringCentral.pyrra) }

--- a/monitoring-central/monitoring-central.libsonnet
+++ b/monitoring-central/monitoring-central.libsonnet
@@ -11,6 +11,7 @@ local kubePrometheus =
   (import '../addons/networkpolicies-disabled.libsonnet') +
   (import '../addons/disable-grafana-auth.libsonnet') +
   (import '../addons/grafana-on-gcp-oauth.libsonnet')(config) +
+  (if std.objectHas(config, 'pyrra') then (import '../addons/pyrra.libsonnet')(config) else {}) +
   {
     values+:: {
       common+: {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
First commit includes Pyrra to monitoring-central while disabling all default SLOs
Second commit make the Prometheus URL in Pyrra's arguments configurable, so we can change it to VictoriaMetrics or to anything else in the future.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/3115
Fixes https://github.com/gitpod-io/ops/issues/3117
