### PR TITLE
Add ingress to Pyrra as opt-in

### DIFF
--- a/addons/pyrra-ingress.libsonnet
+++ b/addons/pyrra-ingress.libsonnet
@@ -1,0 +1,96 @@
+function(config) {
+  assert std.objectHas(config.pyrra, 'DNS') : 'pyrra.DNS required',
+  assert std.objectHas(config.pyrra, 'nodePort') : 'pyrra.nodePort required',
+  assert std.isNumber(config.pyrra.nodePort) : 'pyrra.nodePort should be a number',
+  assert std.objectHas(config.pyrra, 'GCPExternalIpAddress') : 'pyrra.GCPExternalIpAddress required',
+
+
+  pyrra+: {
+    certificate: {
+      apiVersion: 'cert-manager.io/v1',
+      kind: 'Certificate',
+      metadata: {
+        name: 'pyrra',
+        namespace: config.namespace,
+      },
+      spec: {
+        dnsNames: [
+          config.pyrra.DNS,
+        ],
+        issuerRef: {
+          kind: 'ClusterIssuer',
+          name: 'letsencrypt-issuer',
+        },
+        secretName: 'pyrra',
+      },
+    },
+
+    apiService+: {
+      spec+: {
+        type: 'NodePort',
+        ports: std.map(
+          function(p)
+            if p.name == 'http' then
+              p {
+                nodePort: config.pyrra.nodePort,
+              }
+            else p
+          , super.ports
+        ),
+      },
+    },
+
+    ingress: {
+      apiVersion: 'extensions/v1beta1',
+      kind: 'Ingress',
+      metadata: {
+        annotations: {
+          'kubernetes.io/ingress.global-static-ip-name': config.pyrra.GCPExternalIpAddress,
+          'kubernetes.io/ingress.class': 'gce',
+          'cert-manager.io/cluster-issuer': $.pyrra.certificate.spec.issuerRef.name,
+          'networking.gke.io/v1beta1.FrontendConfig': $.pyrra.frontendConfig.metadata.name,
+        },
+        labels: $.pyrra.apiService.metadata.labels,
+        name: 'pyrra',
+        namespace: config.namespace,
+      },
+      spec: {
+        rules: [{
+          host: config.pyrra.DNS,
+          http: {
+            paths: [{
+              backend: {
+                serviceName: $.pyrra.apiService.metadata.name,
+                servicePort: 9099,
+              },
+              path: '/*',
+            }],
+          },
+
+        }],
+        tls: [{
+          hosts: [
+            config.pyrra.DNS,
+          ],
+          secretName: $.pyrra.certificate.spec.secretName,
+        }],
+      },
+    },
+
+    frontendConfig: {
+      apiVersion: 'networking.gke.io/v1beta1',
+      kind: 'FrontendConfig',
+      metadata: {
+        name: 'pyrra',
+        namespace: config.namespace,
+      },
+      spec: {
+        sslPolicy: 'pyrra-ssl-policy',
+        redirectToHttps: {
+          enabled: true,
+          responseCodeName: '301',
+        },
+      },
+    },
+  },
+}

--- a/addons/pyrra.libsonnet
+++ b/addons/pyrra.libsonnet
@@ -1,49 +1,52 @@
-function(config) (import 'kube-prometheus/addons/pyrra.libsonnet') {
-  local defaults = {
-    prometheusURL: 'http://prometheus-k8s.%s.svc.cluster.local:9090' % config.namespace,
-  },
+function(config)
+  (import 'kube-prometheus/addons/pyrra.libsonnet') +
+  (if std.objectHas(config.pyrra, 'DNS') then (import '../addons/pyrra-ingress.libsonnet')(config) else {}) +
+  {
+    local defaults = {
+      prometheusURL: 'http://prometheus-k8s.%s.svc.cluster.local:9090' % config.namespace,
+    },
 
-  local pyrra = self,
-  _config:: defaults + config.pyrra,
+    local pyrra = self,
+    _config:: defaults + config.pyrra,
 
-  pyrra+: {
-    'slo-apiserver-read-response-errors':: {},
-    'slo-apiserver-write-response-errors':: {},
-    'slo-apiserver-read-resource-latency':: {},
-    'slo-apiserver-read-namespace-latency':: {},
-    'slo-apiserver-read-cluster-latency':: {},
-    'slo-kubelet-request-errors':: {},
-    'slo-kubelet-runtime-errors':: {},
-    'slo-coredns-response-errors':: {},
-    'slo-prometheus-operator-reconcile-errors':: {},
-    'slo-prometheus-operator-http-errors':: {},
-    'slo-prometheus-rule-evaluation-failures':: {},
-    'slo-prometheus-sd-kubernetes-errors':: {},
-    'slo-prometheus-query-errors':: {},
-    'slo-prometheus-notification-errors':: {},
+    pyrra+: {
+      'slo-apiserver-read-response-errors':: {},
+      'slo-apiserver-write-response-errors':: {},
+      'slo-apiserver-read-resource-latency':: {},
+      'slo-apiserver-read-namespace-latency':: {},
+      'slo-apiserver-read-cluster-latency':: {},
+      'slo-kubelet-request-errors':: {},
+      'slo-kubelet-runtime-errors':: {},
+      'slo-coredns-response-errors':: {},
+      'slo-prometheus-operator-reconcile-errors':: {},
+      'slo-prometheus-operator-http-errors':: {},
+      'slo-prometheus-rule-evaluation-failures':: {},
+      'slo-prometheus-sd-kubernetes-errors':: {},
+      'slo-prometheus-query-errors':: {},
+      'slo-prometheus-notification-errors':: {},
 
-    apiDeployment+: {
+      apiDeployment+: {
 
-      spec+: {
-        template+: {
-          spec+: {
-            containers: std.map(
-              function(c) c {
-                args:
-                  if c.name == 'pyrra' then
-                    [
-                      'api',
-                      '--api-url=http://%s.%s.svc.cluster.local:9444' % [$.pyrra.kubernetesService.metadata.name, $.pyrra.kubernetesService.metadata.namespace],
-                      '--prometheus-url=%s' % pyrra._config.prometheusURL,
-                    ]
-                  else
-                    [],
-              },
-              super.containers
-            ),
+        spec+: {
+          template+: {
+            spec+: {
+              containers: std.map(
+                function(c) c {
+                  args:
+                    if c.name == 'pyrra' then
+                      [
+                        'api',
+                        '--api-url=http://%s.%s.svc.cluster.local:9444' % [$.pyrra.kubernetesService.metadata.name, $.pyrra.kubernetesService.metadata.namespace],
+                        '--prometheus-url=%s' % pyrra._config.prometheusURL,
+                      ]
+                    else
+                      [],
+                },
+                super.containers
+              ),
+            },
           },
         },
       },
     },
-  },
-}
+  }

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -155,7 +155,10 @@ jsonnet -c -J vendor -m monitoring-central/manifests \
 |||,
     },
     pyrra: {
-        prometheusURL: 'http://victoriametrics.monitoring-central.svc.cluster.local:8428'
+        prometheusURL: 'http://victoriametrics.monitoring-central.svc.cluster.local:8428',
+        DNS: 'http://fake.pyrra.url',
+        nodePort: 32164,
+        GCPExternalIpAddress: 'fake_external_ip_address',
     },
 }" \
 monitoring-central/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Add ingress resources to pyrra, but only if `pyrra.DNS` is set in the `config` external variable.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/3124