### PR TITLE
Conditionaally change slack notification color

### DIFF
--- a/addons/alerting.libsonnet
+++ b/addons/alerting.libsonnet
@@ -77,8 +77,9 @@ function(config) {
         send_resolved: true,
         api_url: webhook,
         channel: channel,
-        title: '[{{ .Status | toUpper }}{{ if eq .Status "firing" }}{{ end }}]',
-        text: '{{ range .Alerts }}\n**Please take immediate action!**\n*Cluster:* {{ .Labels.cluster }}\n*Alert:* {{ .Labels.alertname }}\n*Description:* {{ .Annotations.description }}\n{{ end }}\n',
+        title: '[{{ .CommonLabels.alertname }} {{ .Status | toUpper }} {{ if eq .Status "firing" }}{{ end }}]',
+        text: '{{ range .Alerts }}\n*Severity: {{ .Labels.severity }}*\n*Cluster:* {{ .Labels.cluster }}\n*Alert:* {{ .Labels.alertname }}\n*Description:* {{ .Annotations.description }}\n{{ end }}\n',
+        color: '{{ if eq .Status "firing" -}}{{ if eq .CommonLabels.severity "warning" -}}warning{{- else if eq .CommonLabels.severity "critical" -}}danger{{- else -}}#439FE0{{- end -}}{{ else -}}good{{- end }}',
         actions: [
           {
             type: 'button',


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

## Description
<!-- Describe your changes in detail -->
Since we're now aggregating alerts in a single channel, we need to differentiate alerts depending on their severity.

The result of this PR will be something like this:
![image](https://user-images.githubusercontent.com/24193764/178794003-adf8b38a-c9c2-4b6a-9797-fe1451c14025.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/3083
