### PR TITLE
Increase VictoriaMetrics max query duration

### DIFF
--- a/components/victoriametrics/victoriametrics.libsonnet
+++ b/components/victoriametrics/victoriametrics.libsonnet
@@ -128,7 +128,10 @@ function(params) {
               name: $._config.name,
               image: 'victoriametrics/victoria-metrics:' + $._config.version,
               imagePullPolicy: 'IfNotPresent',
-              args: ['-search.maxUniqueTimeseries=3000000'],
+              args: [
+                '-search.maxUniqueTimeseries=3000000',
+                '-search.maxQueryDuration=60s',
+              ],
               ports: [{
                 containerPort: $._config.port,
               }],


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
While investigating why Pyrra is showing "No data" at some parts of the UI, I've timeouts in Pyrra's logs when performing queries against VictoriaMetrics
```
2022-07-19T15:05:35.657Z        error   VictoriaMetrics/app/vmalert/group.go:292        group "previews-k3s-request-success-ratio": rule "rest_client_requests:burnrate4d": failed to execute: failed to execute query "sum by(host) (rate(rest_client_requests_total{code!~\"2..|4..\",environment=\"preview-environments\",host=~\"127.0.0.1.*\"}[4d])) / sum by(host) (rate(rest_client_requests_total{environment=\"preview-environments\",host=~\"127.0.0.1.*\"}[4d]))": unexpected response code 422 for http://victoriametrics.monitoring-central.svc.cluster.local:8428/api/v1/query?query=sum+by%28host%29+%28rate%28rest_client_requests_total%7Bcode%21~%222..%7C4..%22%2Cenvironment%3D%22preview-environments%22%2Chost%3D~%22127.0.0.1.%2A%22%7D%5B4d%5D%29%29+%2F+sum+by%28host%29+%28rate%28rest_client_requests_total%7Benvironment%3D%22preview-environments%22%2Chost%3D~%22127.0.0.1.%2A%22%7D%5B4d%5D%29%29&step=30s&time=1658243040. Response body {"status":"error","errorType":"422","error":"error when executing query=\"sum by(host) (rate(rest_client_requests_total{code!~\\\"2..|4..\\\",environment=\\\"preview-environments\\\",host=~\\\"127.0.0.1.*\\\"}[4d])) / sum by(host) (rate(rest_client_requests_total{environment=\\\"preview-environments\\\",host=~\\\"127.0.0.1.*\\\"}[4d]))\" for (time=1658243040000, step=30000): timeout exceeded during the query: 30.000 seconds; the timeout can be adjusted with `-search.maxQueryDuration` command-line flag"}
2022-07-19T15:05:38.580Z        error   VictoriaMetrics/app/vmalert/group.go:292        group "workspace-backup-success-ratio": rule "gitpod_ws_manager_workspace_backups:burnrate5m": failed to execute: failed to execute query "sum(rate(gitpod_ws_manager_workspace_backups_failure_total{type=\"REGULAR\"}[5m])) / sum(rate(gitpod_ws_manager_workspace_backups_total{type=\"REGULAR\"}[5m]))": unexpected response code 422 for http://victoriametrics.monitoring-central.svc.cluster.local:8428/api/v1/query?query=sum%28rate%28gitpod_ws_manager_workspace_backups_failure_total%7Btype%3D%22REGULAR%22%7D%5B5m%5D%29%29+%2F+sum%28rate%28gitpod_ws_manager_workspace_backups_total%7Btype%3D%22REGULAR%22%7D%5B5m%5D%29%29&step=30s&time=1658243040. Response body {"status":"error","errorType":"422","error":"error when executing query=\"sum(rate(gitpod_ws_manager_workspace_backups_failure_total{type=\\\"REGULAR\\\"}[5m])) / sum(rate(gitpod_ws_manager_workspace_backups_total{type=\\\"REGULAR\\\"}[5m]))\" for (time=1658243040000, step=30000): timeout exceeded during the query: 30.000 seconds; the timeout can be adjusted with `-search.maxQueryDuration` command-line flag"}
2022-07-19T15:05:39.788Z        error   VictoriaMetrics/app/vmalert/group.go:292        group "gitpod-login-success-ratio": rule "gitpod_server_login_requests:burnrate5m": failed to execute: failed to execute query "sum(rate(gitpod_server_login_requests_total{status=\"failed\"}[5m])) / sum(rate(gitpod_server_login_requests_total[5m]))": unexpected response code 422 for http://victoriametrics.monitoring-central.svc.cluster.local:8428/api/v1/query?query=sum%28rate%28gitpod_server_login_requests_total%7Bstatus%3D%22failed%22%7D%5B5m%5D%29%29+%2F+sum%28rate%28gitpod_server_login_requests_total%5B5m%5D%29%29&step=30s&time=1658243070. Response body {"status":"error","errorType":"422","error":"error when executing query=\"sum(rate(gitpod_server_login_requests_total{status=\\\"failed\\\"}[5m])) / sum(rate(gitpod_server_login_requests_total[5m]))\" for (time=1658243055152, step=30000): timeout exceeded during the query: 30.000 seconds; the timeout can be adjusted with `-search.maxQueryDuration` command-line flag"}
```

This PR increases the query timeout, hoping that metrics are shown again 😬 