### PR TITLE
Update alert channel names

### DIFF
--- a/addons/alerting.libsonnet
+++ b/addons/alerting.libsonnet
@@ -102,7 +102,7 @@ function(config) {
   },
 
 
-  local teamSlackReceiversArr = [slackReceiver(p.team + 'Receiver', '#a_' + p.team + '_alerts', p.webhook) for p in teamWebHookMap],
+  local teamSlackReceiversArr = [slackReceiver(p.team + 'Receiver', '#t_' + p.team + '_alerts', p.webhook) for p in teamWebHookMap],
   local genericSlackReceiverArr = [slackReceiver('genericReceiver', config.alerting.generic.slackChannel, config.alerting.generic.slackWebhookURL)],
   local genericCriticalReceiverArr = [
     if std.objectHas(config.alerting, 'pagerdutyRoutingKey') then


### PR DESCRIPTION
## Description
Updates the alert channel names, to follow the #t_* pattern


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```