### PR TITLE
Revert "Update http-prober version" because of gitpod-io/http-prober#3

### DIFF
--- a/components/probers/probers.libsonnet
+++ b/components/probers/probers.libsonnet
@@ -4,7 +4,7 @@ local defaults = {
   name: 'http-prober',
   namespace: error 'must provide namespace',
   image: 'ghcr.io/arthursens/http-prober',
-  version: 'v0.0.2',
+  version: 'v0.0.1',
   commonLabels: {
     'app.kubernetes.io/name': defaults.name,
     'app.kubernetes.io/part-of': 'kube-prometheus',


### PR DESCRIPTION
This reverts commit 5e514b1d295293d4987c3514d4a30fba58b30b6f.

Since we failed to release http-prober v0.0.2, we got 404

ref. https://github.com/gitpod-io/http-prober/issues/3
