### PR TITLE
Remove Watchdog alert

### DIFF
--- a/lib/alert-filter.libsonnet
+++ b/lib/alert-filter.libsonnet
@@ -13,6 +13,9 @@ local unwatedAlerts = [
   // From node-exporter
   'NodeFilesystemSpaceFillingUp',
   'NodeHighNumberConntrackEntriesUsed',
+
+  // From kube-prometheus
+  'Watchdog',
 ];
 
 {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
A follow-up from https://github.com/gitpod-io/ops/pull/3600. Will stop generating the `Watchdog` alert