### PR TITLE
Fix Cluster Issuer Name

### DIFF
--- a/components/victoriametrics/victoriametrics.libsonnet
+++ b/components/victoriametrics/victoriametrics.libsonnet
@@ -304,7 +304,7 @@ function(params) {
       ],
       issuerRef: {
         kind: 'ClusterIssuer',
-        name: 'letsencrypt-issuer',
+        name: 'letsencrypt-issuer-gitpod-191109',
       },
       secretName: 'victoriametrics-certificate',
     },


### PR DESCRIPTION
## Description
Fix the name of a certificate issuer

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #https://gitpod.slack.com/archives/C01KGM9EBD4/p1659430530676369

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
