### PR TITLE
Include alert summary summary in slack notifications.

### DIFF
--- a/addons/alerting.libsonnet
+++ b/addons/alerting.libsonnet
@@ -83,7 +83,7 @@ function(config) {
           },
         },
         title: '[{{ .CommonLabels.alertname }} {{ .Status | toUpper }} {{ if eq .Status "firing" }}{{ end }}]',
-        text: '{{ range .Alerts }}\n*Summary*: {{ .Labels.severity }}\n*Severity: {{ .Labels.severity }}*\n*Cluster:* {{ .Labels.cluster }}\n*Alert:* {{ .Labels.alertname }}\n*Description:* {{ .Annotations.description }}\n{{ end }}\n',
+        text: '{{ range .Alerts }}\n*Summary*: {{ .Labels.summary }}\n*Severity: {{ .Labels.severity }}*\n*Cluster:* {{ .Labels.cluster }}\n*Alert:* {{ .Labels.alertname }}\n*Description:* {{ .Annotations.description }}\n{{ end }}\n',
         color: '{{ if eq .Status "firing" -}}{{ if eq .CommonLabels.severity "warning" -}}warning{{- else if eq .CommonLabels.severity "critical" -}}danger{{- else -}}#439FE0{{- end -}}{{ else -}}good{{- end }}',
         actions: [
           {

--- a/addons/alerting.libsonnet
+++ b/addons/alerting.libsonnet
@@ -83,7 +83,7 @@ function(config) {
           },
         },
         title: '[{{ .CommonLabels.alertname }} {{ .Status | toUpper }} {{ if eq .Status "firing" }}{{ end }}]',
-        text: '{{ range .Alerts }}\n*Severity: {{ .Labels.severity }}*\n*Cluster:* {{ .Labels.cluster }}\n*Alert:* {{ .Labels.alertname }}\n*Description:* {{ .Annotations.description }}\n{{ end }}\n',
+        text: '{{ range .Alerts }}\n*Summary*: {{ .Labels.severity }}\n*Severity: {{ .Labels.severity }}*\n*Cluster:* {{ .Labels.cluster }}\n*Alert:* {{ .Labels.alertname }}\n*Description:* {{ .Annotations.description }}\n{{ end }}\n',
         color: '{{ if eq .Status "firing" -}}{{ if eq .CommonLabels.severity "warning" -}}warning{{- else if eq .CommonLabels.severity "critical" -}}danger{{- else -}}#439FE0{{- end -}}{{ else -}}good{{- end }}',
         actions: [
           {


### PR DESCRIPTION
Notifications from Certmanager alerts did not give us enough information for debugging:
* They don't tell us what certificate is failing
* They don't tell us what namespace this certificate is

While investigating why I've noticed that they actually do[[1](https://github.com/gitpod-io/observability/blob/64e8be08bf3ae4fee7821e3997e3ff9c396ca6c7/vendor/gitlab.com/uneeq-oss/cert-manager-mixin/alerts/certificates.libsonnet#L19)][[2](https://github.com/gitpod-io/observability/blob/64e8be08bf3ae4fee7821e3997e3ff9c396ca6c7/vendor/gitlab.com/uneeq-oss/cert-manager-mixin/alerts/certificates.libsonnet#L38)], it's just we don't provide this information when sending this information. 

In fact, all our alerts from gitpod-io/gitpod also have the `summary` label. So we might as well include it in the notification