### PR TITLE
Add a button to PD/Slack with grafana query url, optional dashboard url

### DIFF
--- a/addons/alerting.libsonnet
+++ b/addons/alerting.libsonnet
@@ -112,7 +112,7 @@ function(config) {
             type: 'button',
             text: 'Dashboard :grafana:',
             url: '{{ .CommonAnnotations.dashboard_url}}',
-          }
+          },
         ],
       },
     ],
@@ -125,19 +125,19 @@ function(config) {
         send_resolved: true,
         routing_key: key,
         links: [
-            {
-                text: 'Runbook :book:',
-                href: '{{ .CommonAnnotations.runbook_url }}'
-            },
-            {
-                text: 'Query :prometheus:',
-                href: queryButtonTmpl
-            },
-            {
-                text: 'Dashboard :grafana:',
-                href: '{{ .CommonAnnotations.dashboard_url }}'
-            }
-        ]
+          {
+            text: 'Runbook :book:',
+            href: '{{ .CommonAnnotations.runbook_url }}',
+          },
+          {
+            text: 'Query :prometheus:',
+            href: queryButtonTmpl,
+          },
+          {
+            text: 'Dashboard :grafana:',
+            href: '{{ .CommonAnnotations.dashboard_url }}',
+          },
+        ],
       },
     ],
   },

--- a/addons/alerting.libsonnet
+++ b/addons/alerting.libsonnet
@@ -70,6 +70,18 @@ function(config) {
   local infoRoute = trimRoutesTmpl(std.manifestYamlDoc(infoRouteTmpl, quote_keys=false)),
   local allRoutes = std.stripChars(criticalRoute + '\n' + teamRoutes + '\n' + warningRoute + '\n' + infoRoute, '[]'),
 
+
+  # This was a nightmare to do. The URL that we get from the query that triggered the alert is the address of the prometheus
+  # Since we can't access it from outside, we want to link to grafana with the query
+  # So we descent into madness, i.e. we use regex to replace the relevant parts and concatenate that with the url of our grafana. In order of execution
+  # "reReplaceAll "%22" "%5C%22" (index .Alerts 0).GeneratorURL - .GeneratorURL is a link to the prometheus with the query. We replace %22 (", with (\"), as this is what makes grafana happy
+  # reReplaceAll ".*expr=" ... - The URL is something like: http://prometheus.:9090/graph?g0.range_input=1h&g0.expr=QUERY&g0.tab=1 We keep everything after `expr=` and replace the rest with our grafana URL
+  # reReplaceAll "&g0.tab=1" "%22%7D%5D%7D" - replaces the last bit (&g0.tab=1) with ("}]})
+  # reReplaceAll `\\+` "%20" - replace all (+) with spaces ( ) - again to make grafana happy
+  # reReplaceAll "%0A" "" - newlines with nothing
+  # reReplaceAll "%28" "(" | reReplaceAll "%29" ")" - self explanatory
+  local queryButtonTmpl = '{{ reReplaceAll "%22" "%5C%22" (index .Alerts 0).GeneratorURL | reReplaceAll ".*expr=" "https://grafana.gitpod.io/explore?orgId=1&left=%7B%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D,%22datasource%22:%22VictoriaMetrics%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22" | reReplaceAll "&g0.tab=1" "%22%7D%5D%7D" | reReplaceAll `\\+` "%20" | reReplaceAll "%0A" "" | reReplaceAll "%28" "(" | reReplaceAll "%29" ")" }}',
+
   local slackReceiver(name, channel) = {
     name: name,
     slack_configs: [
@@ -83,7 +95,7 @@ function(config) {
           },
         },
         title: '[{{ .CommonLabels.alertname }} {{ .Status | toUpper }} {{ if eq .Status "firing" }}{{ end }}]',
-        text: '{{ range .Alerts }}\n*Summary*: {{ .Labels.summary }}\n*Severity: {{ .Labels.severity }}*\n*Cluster:* {{ .Labels.cluster }}\n*Alert:* {{ .Labels.alertname }}\n*Description:* {{ .Annotations.description }}\n{{ end }}\n',
+        text: '{{ range .Alerts }}\n*Summary*: {{ .Annotations.summary }}\n*Severity: {{ .Labels.severity }}*\n*Cluster:* {{ .Labels.cluster }}\n*Alert:* {{ .Labels.alertname }}\n*Description:* {{ .Annotations.description }}\n{{ end }}\n',
         color: '{{ if eq .Status "firing" -}}{{ if eq .CommonLabels.severity "warning" -}}warning{{- else if eq .CommonLabels.severity "critical" -}}danger{{- else -}}#439FE0{{- end -}}{{ else -}}good{{- end }}',
         actions: [
           {
@@ -91,6 +103,16 @@ function(config) {
             text: 'Runbook :book:',
             url: '{{ .CommonAnnotations.runbook_url }}',
           },
+          {
+            type: 'button',
+            text: 'Query :prometheus:',
+            url: queryButtonTmpl,
+          },
+          {
+            type: 'button',
+            text: 'Dashboard :grafana:',
+            url: '{{ .CommonAnnotations.dashboard_url}}',
+          }
         ],
       },
     ],
@@ -102,6 +124,20 @@ function(config) {
       {
         send_resolved: true,
         routing_key: key,
+        links: [
+            {
+                text: 'Runbook :book:',
+                href: '{{ .CommonAnnotations.runbook_url }}'
+            },
+            {
+                text: 'Query :prometheus:',
+                href: queryButtonTmpl
+            },
+            {
+                text: 'Dashboard :grafana:',
+                href: '{{ .CommonAnnotations.dashboard_url }}'
+            }
+        ]
       },
     ],
   },

--- a/addons/alerting.libsonnet
+++ b/addons/alerting.libsonnet
@@ -71,15 +71,15 @@ function(config) {
   local allRoutes = std.stripChars(criticalRoute + '\n' + teamRoutes + '\n' + warningRoute + '\n' + infoRoute, '[]'),
 
 
-  # This was a nightmare to do. The URL that we get from the query that triggered the alert is the address of the prometheus
-  # Since we can't access it from outside, we want to link to grafana with the query
-  # So we descent into madness, i.e. we use regex to replace the relevant parts and concatenate that with the url of our grafana. In order of execution
-  # "reReplaceAll "%22" "%5C%22" (index .Alerts 0).GeneratorURL - .GeneratorURL is a link to the prometheus with the query. We replace %22 (", with (\"), as this is what makes grafana happy
-  # reReplaceAll ".*expr=" ... - The URL is something like: http://prometheus.:9090/graph?g0.range_input=1h&g0.expr=QUERY&g0.tab=1 We keep everything after `expr=` and replace the rest with our grafana URL
-  # reReplaceAll "&g0.tab=1" "%22%7D%5D%7D" - replaces the last bit (&g0.tab=1) with ("}]})
-  # reReplaceAll `\\+` "%20" - replace all (+) with spaces ( ) - again to make grafana happy
-  # reReplaceAll "%0A" "" - newlines with nothing
-  # reReplaceAll "%28" "(" | reReplaceAll "%29" ")" - self explanatory
+  // This was a nightmare to do. The URL that we get from the query that triggered the alert is the address of the prometheus
+  // Since we can't access it from outside, we want to link to grafana with the query
+  // So we descent into madness, i.e. we use regex to replace the relevant parts and concatenate that with the url of our grafana. In order of execution
+  // "reReplaceAll "%22" "%5C%22" (index .Alerts 0).GeneratorURL - .GeneratorURL is a link to the prometheus with the query. We replace %22 (", with (\"), as this is what makes grafana happy
+  // reReplaceAll ".*expr=" ... - The URL is something like: http://prometheus.:9090/graph?g0.range_input=1h&g0.expr=QUERY&g0.tab=1 We keep everything after `expr=` and replace the rest with our grafana URL
+  // reReplaceAll "&g0.tab=1" "%22%7D%5D%7D" - replaces the last bit (&g0.tab=1) with ("}]})
+  // reReplaceAll `\\+` "%20" - replace all (+) with spaces ( ) - again to make grafana happy
+  // reReplaceAll "%0A" "" - newlines with nothing
+  // reReplaceAll "%28" "(" | reReplaceAll "%29" ")" - self explanatory
   local queryButtonTmpl = '{{ reReplaceAll "%22" "%5C%22" (index .Alerts 0).GeneratorURL | reReplaceAll ".*expr=" "https://grafana.gitpod.io/explore?orgId=1&left=%7B%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D,%22datasource%22:%22VictoriaMetrics%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22" | reReplaceAll "&g0.tab=1" "%22%7D%5D%7D" | reReplaceAll `\\+` "%20" | reReplaceAll "%0A" "" | reReplaceAll "%28" "(" | reReplaceAll "%29" ")" }}',
 
   local slackReceiver(name, channel) = {

--- a/hack/prepare-kind.sh
+++ b/hack/prepare-kind.sh
@@ -10,11 +10,12 @@ if [[ $? != 0 ]]; then
     | tr -d \" \
     | wget -qi -
     mv kind-linux-amd64 tmp/bin/kind && chmod +x tmp/bin/kind
+    export PATH=$PATH:$(pwd)/tmp/bin
 fi
 
-cluster_created=$($PWD/tmp/bin/kind get clusters 2>&1)
+cluster_created=$(kind get clusters 2>&1)
 if [[ "$cluster_created" == "No kind clusters found." ]]; then 
-    $PWD/tmp/bin/kind create cluster --config $PWD/.github/workflows/kind/config.yml
+    kind create cluster --config $PWD/.github/workflows/kind/config.yml
 else
     echo "Cluster '$cluster_created' already present" 
 fi 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
What it says on the tin.

<img width="612" alt="image" src="https://user-images.githubusercontent.com/5501705/183088288-d780bda7-5533-4d64-967d-8624a5a59024.png">

The PagerDuty links don't show up as a button in Slack - but they will appear when the alert is opened: 
<img width="1407" alt="image" src="https://user-images.githubusercontent.com/5501705/183088466-22651933-dacb-443d-b806-9cf3626835b5.png">

Or they will show up if the details are expanded in Slack `More Actions -> View Details`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
