### PR TITLE
Add prometheus-operator resources

### DIFF
--- a/installer/pkg/components/components.go
+++ b/installer/pkg/components/components.go
@@ -3,8 +3,9 @@ package components
 import (
 	"github.com/gitpod-io/observability/installer/pkg/common"
 	nodeExporter "github.com/gitpod-io/observability/installer/pkg/components/node-exporter"
+	"github.com/gitpod-io/observability/installer/pkg/components/prometheusOperator"
 	"github.com/gitpod-io/observability/installer/pkg/components/pyrra"
 )
 
 var MonitoringCentralObjects = common.MergeLists(pyrra.Objects)
-var MonitoringSatelliteObjects = common.MergeLists(pyrra.Objects, nodeExporter.Objects)
+var MonitoringSatelliteObjects = common.MergeLists(pyrra.Objects, nodeExporter.Objects, prometheusOperator.Objects)

--- a/installer/pkg/components/prometheusOperator/clusterrole.go
+++ b/installer/pkg/components/prometheusOperator/clusterrole.go
@@ -1,0 +1,96 @@
+package prometheusOperator
+
+import (
+	"github.com/gitpod-io/observability/installer/pkg/common"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func clusterRole() []runtime.Object {
+	return []runtime.Object{
+		&rbacv1.ClusterRole{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "rbac.authorization.k8s.io/v1",
+				Kind:       "ClusterRole",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: Namespace,
+				Labels:    common.Labels(Name, Component, App, Version),
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"monitoring.coreos.com"},
+					Resources: []string{
+						"alertmanagers",
+						"alertmanagers/finalizers",
+						"alertmanagerconfigs",
+						"prometheuses",
+						"prometheuses/finalizers",
+						"prometheuses/status",
+						"thanosrulers",
+						"thanosrulers/finalizers",
+						"servicemonitors",
+						"podmonitors",
+						"probes",
+						"prometheusrules",
+					},
+					Verbs: []string{"*"},
+				},
+				{
+					APIGroups: []string{"apps"},
+					Resources: []string{"statefulsets"},
+					Verbs:     []string{"*"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"configmaps", "secrets"},
+					Verbs:     []string{"*"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"list", "delete"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"services", "services/finalizers", "endpoints"},
+					Verbs:     []string{"get", "create", "update", "delete"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"nodes"},
+					Verbs:     []string{"list", "watch"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"namespaces"},
+					Verbs:     []string{"list", "watch", "get"},
+				},
+				{
+					APIGroups: []string{"networking.k8s.io"},
+					Resources: []string{"ingresses"},
+					Verbs:     []string{"list", "watch", "get"},
+				},
+				{
+					APIGroups: []string{"authentication.k8s.io"},
+					Resources: []string{"tokenreviews"},
+					Verbs:     []string{"create"},
+				},
+				{
+					APIGroups: []string{"authorization.k8s.io"},
+					Resources: []string{"subjectaccessreviews"},
+					Verbs:     []string{"create"},
+				},
+				{
+					APIGroups: []string{"policy"},
+					Resources: []string{"podsecuritypolicies"},
+					Verbs:     []string{"use"},
+					// TODO: The psp name will be a constant declared in the 'common' pkg.
+					ResourceNames: []string{"kube-prometheus-restricted"},
+				},
+			},
+		},
+	}
+}

--- a/installer/pkg/components/prometheusOperator/clusterrolebinding.go
+++ b/installer/pkg/components/prometheusOperator/clusterrolebinding.go
@@ -1,0 +1,36 @@
+package prometheusOperator
+
+import (
+	"github.com/gitpod-io/observability/installer/pkg/common"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func clusterRoleBinding() []runtime.Object {
+	return []runtime.Object{
+		&rbacv1.ClusterRoleBinding{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "rbac.authorization.k8s.io/v1",
+				Kind:       "ClusterRoleBinding",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: Namespace,
+				Labels:    common.Labels(Name, Component, App, Version),
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      Name,
+					Namespace: Namespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "ClusterRole",
+				APIGroup: "rbac.authorization.k8s.io",
+				Name:     Name,
+			},
+		},
+	}
+}

--- a/installer/pkg/components/prometheusOperator/constants.go
+++ b/installer/pkg/components/prometheusOperator/constants.go
@@ -1,0 +1,18 @@
+package prometheusOperator
+
+import (
+	"github.com/gitpod-io/observability/installer/pkg/common"
+)
+
+const (
+	Name      = "prometheus-operator"
+	App       = "monitoring-satellite"
+	Version   = "0.58.0"
+	Namespace = "monitoring-satellite"
+	ImageURL  = "quay.io/prometheus-operator/prometheus-operator"
+	Component = "controller"
+)
+
+func prometheusOperatorLabels() map[string]string {
+	return common.Labels(Name, Component, App, Version)
+}

--- a/installer/pkg/components/prometheusOperator/deployment.go
+++ b/installer/pkg/components/prometheusOperator/deployment.go
@@ -1,0 +1,106 @@
+package prometheusOperator
+
+import (
+	"fmt"
+
+	"github.com/gitpod-io/observability/installer/pkg/common"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+)
+
+func deployment() []runtime.Object {
+	return []runtime.Object{
+		&appsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: Namespace,
+				Labels:    common.Labels(Name, Component, App, Version),
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: common.Labels(Name, Component, App, Version)},
+				Replicas: pointer.Int32(1),
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      Name,
+						Namespace: Namespace,
+						Labels:    common.Labels(Name, Component, App, Version),
+					},
+					Spec: corev1.PodSpec{
+						AutomountServiceAccountToken: pointer.Bool(true),
+						Containers: []corev1.Container{{
+							Name:            Name,
+							Image:           fmt.Sprintf("%s:v%s", ImageURL, Version),
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Args: []string{
+								"--kubelet-service=kube-system/kubelet",
+								fmt.Sprintf("--prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v%s", Version),
+							},
+							Ports: []corev1.ContainerPort{{
+								ContainerPort: 8080,
+								Name:          "http",
+							}},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("1000Mi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: pointer.Bool(false),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+								ReadOnlyRootFilesystem: pointer.Bool(true),
+							},
+						},
+							{
+								Name:  "kube-rbac-proxy",
+								Image: "quay.io/brancz/kube-rbac-proxy:v0.13.0",
+								Args: []string{
+									"--logtostderr",
+									"--secure-listen-address=:8443",
+									"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+									"--upstream=http://127.0.0.1:8080/",
+								},
+								Ports: []corev1.ContainerPort{
+									{Name: "https", ContainerPort: 8443},
+								},
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("20m"),
+										corev1.ResourceMemory: resource.MustParse("40Mi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("10m"),
+										corev1.ResourceMemory: resource.MustParse("20Mi"),
+									},
+								},
+								SecurityContext: &corev1.SecurityContext{
+									AllowPrivilegeEscalation: pointer.Bool(false),
+									ReadOnlyRootFilesystem:   pointer.Bool(true),
+									RunAsUser:                pointer.Int64(65532),
+									RunAsGroup:               pointer.Int64(65532),
+									RunAsNonRoot:             pointer.Bool(true),
+									Capabilities: &corev1.Capabilities{
+										Drop: []corev1.Capability{"ALL"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/installer/pkg/components/prometheusOperator/objects.go
+++ b/installer/pkg/components/prometheusOperator/objects.go
@@ -1,0 +1,14 @@
+package prometheusOperator
+
+import (
+	"github.com/gitpod-io/observability/installer/pkg/common"
+)
+
+var Objects = common.MergeLists(
+	service(),
+	deployment(),
+	serviceAccount(),
+	clusterRole(),
+	clusterRoleBinding(),
+	serviceMonitor(),
+)

--- a/installer/pkg/components/prometheusOperator/service.go
+++ b/installer/pkg/components/prometheusOperator/service.go
@@ -1,0 +1,35 @@
+package prometheusOperator
+
+import (
+	"github.com/gitpod-io/observability/installer/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func service() []runtime.Object {
+	return []runtime.Object{
+		&corev1.Service{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "apps/v1",
+				Kind:       "Service",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: Namespace,
+				Labels:    common.Labels(Name, Component, App, Version),
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "https",
+						Port:       8443,
+						TargetPort: intstr.IntOrString{IntVal: 8443},
+					},
+				},
+				Selector: common.Labels(Name, Component, App, Version),
+			},
+		},
+	}
+}

--- a/installer/pkg/components/prometheusOperator/serviceMonitor.go
+++ b/installer/pkg/components/prometheusOperator/serviceMonitor.go
@@ -1,0 +1,39 @@
+package prometheusOperator
+
+import (
+	"github.com/gitpod-io/observability/installer/pkg/common"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func serviceMonitor() []runtime.Object {
+	return []runtime.Object{
+		&monitoringv1.ServiceMonitor{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "monitoring.coreos.com/v1",
+				Kind:       "ServiceMonitor",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: Namespace,
+				Labels:    common.Labels(Name, Component, App, Version),
+			},
+			Spec: monitoringv1.ServiceMonitorSpec{
+				Endpoints: []monitoringv1.Endpoint{
+					{
+						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+						HonorLabels:     true,
+						Port:            "https",
+						Scheme:          "https",
+						TLSConfig: &monitoringv1.TLSConfig{
+							SafeTLSConfig: monitoringv1.SafeTLSConfig{
+								InsecureSkipVerify: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/installer/pkg/components/prometheusOperator/serviceaccount.go
+++ b/installer/pkg/components/prometheusOperator/serviceaccount.go
@@ -1,0 +1,24 @@
+package prometheusOperator
+
+import (
+	"github.com/gitpod-io/observability/installer/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func serviceAccount() []runtime.Object {
+	return []runtime.Object{
+		&corev1.ServiceAccount{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "apps/v1",
+				Kind:       "ServiceAccount",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: Namespace,
+				Labels:    common.Labels(Name, Component, App, Version),
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
```console
go run installer/main.go render > output.yaml
code output.yaml
```

Verity prometheus operator manifests are being rendered as expected