### PR TITLE
mixin-importer: Return rules as runtime.Object

### DIFF
--- a/installer/cmd/render.go
+++ b/installer/cmd/render.go
@@ -35,7 +35,7 @@ var renderCmd = &cobra.Command{
 }
 
 func renderKubernetesObjects() ([]string, error) {
-	objs := components.MonitoringSatelliteObjects
+	objs := components.MonitoringSatelliteObjects()
 
 	k8s := make([]string, 0)
 	for _, o := range objs {

--- a/installer/pkg/components/components.go
+++ b/installer/pkg/components/components.go
@@ -5,7 +5,15 @@ import (
 	nodeExporter "github.com/gitpod-io/observability/installer/pkg/components/node-exporter"
 	"github.com/gitpod-io/observability/installer/pkg/components/prometheusOperator"
 	"github.com/gitpod-io/observability/installer/pkg/components/pyrra"
+	"github.com/gitpod-io/observability/installer/pkg/importer"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var MonitoringCentralObjects = common.MergeLists(pyrra.Objects)
-var MonitoringSatelliteObjects = common.MergeLists(pyrra.Objects, nodeExporter.Objects, prometheusOperator.Objects)
+
+func MonitoringSatelliteObjects() []runtime.Object {
+	mixinImporter := importer.NewMixinImporter("https://github.com/gitpod-io/observability", "")
+	mixinRules := mixinImporter.ImportPrometheusRules()
+
+	return common.MergeLists(pyrra.Objects, nodeExporter.Objects, prometheusOperator.Objects, mixinRules)
+}

--- a/installer/pkg/importer/mixin.go
+++ b/installer/pkg/importer/mixin.go
@@ -1,10 +1,14 @@
 package importer
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/google/go-jsonnet"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
@@ -45,13 +49,14 @@ func NewMixinImporter(gitURL, path string) *MixinImporter {
 	}
 }
 
-func (m MixinImporter) ImportPrometheusRules() {
+func (m MixinImporter) ImportPrometheusRules() []runtime.Object {
+	m.cloneRepository()
+
 	jsonnetImports := []string{platformMixinImport, ideMixinImport, webappMixinImport, workspaceMixinImport}
 	imports := strings.Join(jsonnetImports, "\n")
 	snippet := fmt.Sprintf(rulesSnippet, imports)
 
 	vm := jsonnet.MakeVM()
-	m.cloneRepository()
 	vm.Importer(&jsonnet.FileImporter{
 		JPaths: []string{fmt.Sprintf("%s/vendor", clonePath)},
 	})
@@ -61,5 +66,41 @@ func (m MixinImporter) ImportPrometheusRules() {
 		fmt.Println(err)
 	}
 
-	fmt.Println(out)
+	return unmarshalMixinToRuntimeObject(out)
+}
+
+func unmarshalMixinToRuntimeObject(j string) []runtime.Object {
+	var result map[string]interface{}
+	err := json.Unmarshal([]byte(j), &result)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// 'prometheusRules' is the key defined in the variable 'rulesSnippet'!
+	prometheusRules := result["prometheusRules"].(map[string]interface{})
+	rulesAsJson, err := json.Marshal(prometheusRules)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	var ruleSpec monitoringv1.PrometheusRuleSpec
+	err = json.Unmarshal(rulesAsJson, &ruleSpec)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	return []runtime.Object{
+		&monitoringv1.PrometheusRule{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "monitoring.coreos.com/v1",
+				Kind:       "PrometheusRule",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gitpod-monitoring",
+				//TODO: get namespace from config
+				Namespace: "monitoring-satellite",
+			},
+			Spec: ruleSpec,
+		},
+	}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PRs handles the JSON returned as a result from jsonnet and transform it into a valid `[]Runtime.Object`, so it can be imported and handled the same way we handle all other manifests.

## How to test
<!-- Provide steps to test this PR -->
```console
go run installer/main.go render > output.yaml
code output.yaml
```

Verify that the prometheus rules are valid! You can even deploy them into a KinD cluster to make sure :) 