### PR TITLE
prober manifests

### DIFF
--- a/installer/pkg/common/common.go
+++ b/installer/pkg/common/common.go
@@ -18,3 +18,7 @@ func Labels(name, component, app, version string) map[string]string {
 		"app.kubernetes.io/version":   version,
 	}
 }
+
+func ToPointer[T any](o T) *T {
+	return &o
+}

--- a/installer/pkg/components/probers/constants.go
+++ b/installer/pkg/components/probers/constants.go
@@ -1,0 +1,10 @@
+package probers
+
+const (
+	Name      = "http-prober"
+	App       = "kube-prometheus"
+	Version   = "0.0.1"
+	Namespace = "monitoring-satellite"
+	ImageURL  = "ghcr.io/arthursens/http-prober"
+	Component = "http-prober"
+)

--- a/installer/pkg/components/probers/deployment.go
+++ b/installer/pkg/components/probers/deployment.go
@@ -1,0 +1,46 @@
+package probers
+
+import (
+	"fmt"
+
+	"github.com/gitpod-io/observability/installer/pkg/common"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func deployment() []runtime.Object {
+	return []runtime.Object{
+		&appsv1.Deployment{
+			TypeMeta: common.DeploymentType,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: Namespace,
+				Labels:    common.Labels(Name, Component, App, Version),
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: common.Labels(Name, Component, App, Version)},
+				Replicas: common.ToPointer(int32(1)),
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      Name,
+						Namespace: Namespace,
+						Labels:    common.Labels(Name, Component, App, Version),
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:            Name,
+							Image:           fmt.Sprintf("%s:v%s", ImageURL, Version),
+							ImagePullPolicy: corev1.PullIfNotPresent,
+						}},
+						NodeSelector: map[string]string{
+							"kubernetes.io/os": "linux",
+							"nodepool":         "monitoring",
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/installer/pkg/components/probers/service.go
+++ b/installer/pkg/components/probers/service.go
@@ -1,0 +1,37 @@
+package probers
+
+import (
+	"github.com/gitpod-io/observability/installer/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func service() []runtime.Object {
+	return []runtime.Object{
+		&corev1.Service{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Service",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: Namespace,
+				Labels:    common.Labels(Name, Component, App, Version),
+			},
+			Spec: corev1.ServiceSpec{
+				Type: "ClusterIP",
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "metrics",
+						Port:       8080,
+						TargetPort: intstr.IntOrString{IntVal: 8080},
+						Protocol:   "TCP",
+					},
+				},
+				Selector: common.Labels(Name, Component, App, Version),
+			},
+		},
+	}
+}

--- a/installer/pkg/components/probers/servicemonitor.go
+++ b/installer/pkg/components/probers/servicemonitor.go
@@ -1,0 +1,40 @@
+package probers
+
+import (
+	"github.com/gitpod-io/observability/installer/pkg/common"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func serviceMonitor() []runtime.Object {
+	return []runtime.Object{
+		&monitoringv1.ServiceMonitor{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "monitoring.coreos.com/v1",
+				Kind:       "ServiceMonitor",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: Namespace,
+				Labels:    common.Labels(Name, Component, App, Version),
+			},
+			Spec: monitoringv1.ServiceMonitorSpec{
+				Endpoints: []monitoringv1.Endpoint{
+					{
+						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+						Port:            "metrics",
+						Interval:        "60s",
+					},
+				},
+				NamespaceSelector: monitoringv1.NamespaceSelector{
+					MatchNames: []string{Namespace},
+				},
+				JobLabel: "app.kubernetes.io/name",
+				Selector: metav1.LabelSelector{
+					MatchLabels: common.Labels(Name, Component, App, Version),
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Description
HTTP Prober manifests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
