### PR TITLE
service monitor resources

### DIFF
--- a/installer/pkg/components/cert-manager/constants.go
+++ b/installer/pkg/components/cert-manager/constants.go
@@ -1,4 +1,4 @@
-package certManager
+package certmanager
 
 const (
 	Namespace = "certmanager"

--- a/installer/pkg/components/cert-manager/constants.go
+++ b/installer/pkg/components/cert-manager/constants.go
@@ -1,0 +1,25 @@
+package certManager
+
+const (
+	Namespace = "certmanager"
+	App       = "certmanager"
+	Component = "certmanager"
+)
+
+var (
+	matchLabels = map[string]string{
+		"app.kubernetes.io/component": "prometheus",
+		"app.kubernetes.io/instance":  "k8s",
+		"app.kubernetes.io/name":      "prometheus",
+		"app.kubernetes.io/part-of":   "kube-prometheus",
+		"app.kubernetes.io/version":   "2.37.0",
+	}
+)
+
+func labels() map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/component": Component,
+		"app.kubernetes.io/name":      App,
+		"app.kubernetes.io/part-of":   "kube-prometheus",
+	}
+}

--- a/installer/pkg/components/cert-manager/networkpolicy.go
+++ b/installer/pkg/components/cert-manager/networkpolicy.go
@@ -1,12 +1,13 @@
-package certManager
+package certmanager
 
 import (
 	"fmt"
-	"github.com/gitpod-io/observability/installer/pkg/common"
 
 	networkv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gitpod-io/observability/installer/pkg/common"
 )
 
 func networkPolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
@@ -14,7 +15,7 @@ func networkPolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&networkv1.NetworkPolicy{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "networking.k8s.io/v1",
-				Kind:       "ServiceMonitor",
+				Kind:       "NetworkPolicy",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("%s-allow-kube-prometheus", Component),

--- a/installer/pkg/components/cert-manager/networkpolicy.go
+++ b/installer/pkg/components/cert-manager/networkpolicy.go
@@ -1,4 +1,4 @@
-package werft
+package certManager
 
 import (
 	"fmt"
@@ -24,7 +24,8 @@ func networkPolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Spec: networkv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						"component": Component,
+						"app":                         "cert-manager",
+						"app.kubernetes.io/component": "controller",
 					},
 				},
 				Ingress: []networkv1.NetworkPolicyIngressRule{

--- a/installer/pkg/components/cert-manager/objects.go
+++ b/installer/pkg/components/cert-manager/objects.go
@@ -1,0 +1,11 @@
+package certManager
+
+import (
+	"github.com/gitpod-io/observability/installer/pkg/common"
+)
+
+var Objects = common.CompositeRenderFunc(
+	networkPolicy,
+	service,
+	serviceMonitor,
+)

--- a/installer/pkg/components/cert-manager/objects.go
+++ b/installer/pkg/components/cert-manager/objects.go
@@ -1,4 +1,4 @@
-package certManager
+package certmanager
 
 import (
 	"github.com/gitpod-io/observability/installer/pkg/common"

--- a/installer/pkg/components/cert-manager/service.go
+++ b/installer/pkg/components/cert-manager/service.go
@@ -1,0 +1,34 @@
+package certManager
+
+import (
+	"fmt"
+	"github.com/gitpod-io/observability/installer/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func service(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		&corev1.Service{
+			TypeMeta: common.ServiceType,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-metrics", App),
+				Namespace: Namespace,
+				Labels:    labels(),
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name: "metrics",
+						Port: 9402,
+					},
+				},
+				Selector: map[string]string{
+					"app":                         "cert-manager",
+					"app.kubernetes.io/component": "controller",
+				},
+			},
+		},
+	}, nil
+}

--- a/installer/pkg/components/cert-manager/service.go
+++ b/installer/pkg/components/cert-manager/service.go
@@ -1,11 +1,13 @@
-package certManager
+package certmanager
 
 import (
 	"fmt"
-	"github.com/gitpod-io/observability/installer/pkg/common"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gitpod-io/observability/installer/pkg/common"
 )
 
 func service(ctx *common.RenderContext) ([]runtime.Object, error) {

--- a/installer/pkg/components/cert-manager/servicemonitor.go
+++ b/installer/pkg/components/cert-manager/servicemonitor.go
@@ -1,10 +1,11 @@
-package certManager
+package certmanager
 
 import (
-	"github.com/gitpod-io/observability/installer/pkg/common"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gitpod-io/observability/installer/pkg/common"
 )
 
 func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {

--- a/installer/pkg/components/cert-manager/servicemonitor.go
+++ b/installer/pkg/components/cert-manager/servicemonitor.go
@@ -1,0 +1,40 @@
+package certManager
+
+import (
+	"github.com/gitpod-io/observability/installer/pkg/common"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		&monitoringv1.ServiceMonitor{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "monitoring.coreos.com/v1",
+				Kind:       "ServiceMonitor",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      App,
+				Namespace: Namespace,
+				Labels:    labels(),
+			},
+			Spec: monitoringv1.ServiceMonitorSpec{
+				JobLabel: "app.kubernetes.io/name",
+				Endpoints: []monitoringv1.Endpoint{
+					{
+						Interval:    "30s",
+						Port:        "metrics",
+						HonorLabels: true,
+					},
+				},
+				NamespaceSelector: monitoringv1.NamespaceSelector{
+					MatchNames: []string{Namespace},
+				},
+				Selector: metav1.LabelSelector{
+					MatchLabels: labels(),
+				},
+			},
+		},
+	}, nil
+}

--- a/installer/pkg/components/components.go
+++ b/installer/pkg/components/components.go
@@ -3,6 +3,7 @@ package components
 import (
 	"github.com/gitpod-io/observability/installer/pkg/common"
 	"github.com/gitpod-io/observability/installer/pkg/components/alertmanager"
+	certManager "github.com/gitpod-io/observability/installer/pkg/components/cert-manager"
 	"github.com/gitpod-io/observability/installer/pkg/components/gitpod"
 	kubestateMetrics "github.com/gitpod-io/observability/installer/pkg/components/kubestate-metrics"
 	nodeExporter "github.com/gitpod-io/observability/installer/pkg/components/node-exporter"
@@ -32,5 +33,6 @@ func MonitoringSatelliteObjects(ctx *common.RenderContext) common.RenderFunc {
 		pyrra.Objects(ctx),
 		werft.Objects(ctx),
 		gitpod.Objects(ctx),
+		certManager.Objects,
 	)
 }

--- a/installer/pkg/components/components.go
+++ b/installer/pkg/components/components.go
@@ -3,12 +3,14 @@ package components
 import (
 	"github.com/gitpod-io/observability/installer/pkg/common"
 	"github.com/gitpod-io/observability/installer/pkg/components/alertmanager"
+	"github.com/gitpod-io/observability/installer/pkg/components/gitpod"
 	kubestateMetrics "github.com/gitpod-io/observability/installer/pkg/components/kubestate-metrics"
 	nodeExporter "github.com/gitpod-io/observability/installer/pkg/components/node-exporter"
 	otelCollector "github.com/gitpod-io/observability/installer/pkg/components/otel-collector"
 	"github.com/gitpod-io/observability/installer/pkg/components/prometheus"
 	prometheusoperator "github.com/gitpod-io/observability/installer/pkg/components/prometheus-operator"
 	"github.com/gitpod-io/observability/installer/pkg/components/pyrra"
+	"github.com/gitpod-io/observability/installer/pkg/components/werft"
 	"github.com/gitpod-io/observability/installer/pkg/importer"
 )
 
@@ -28,5 +30,7 @@ func MonitoringSatelliteObjects(ctx *common.RenderContext) common.RenderFunc {
 		otelCollector.Objects(ctx),
 		prometheus.Objects,
 		pyrra.Objects(ctx),
+		werft.Objects(ctx),
+		gitpod.Objects(ctx),
 	)
 }

--- a/installer/pkg/components/gitpod/constants.go
+++ b/installer/pkg/components/gitpod/constants.go
@@ -1,0 +1,45 @@
+package gitpod
+
+const (
+	Namespace = "monitoring-satellite"
+	App       = "gitpod"
+)
+
+var (
+	matchLabels = map[string]string{
+		"app.kubernetes.io/component": "prometheus",
+		"app.kubernetes.io/instance":  "k8s",
+		"app.kubernetes.io/name":      "prometheus",
+		"app.kubernetes.io/part-of":   "kube-prometheus",
+		"app.kubernetes.io/version":   "2.37.0",
+	}
+	targets = []string{
+		"agent-smith",
+		"blobserve",
+		"containerd-metrics",
+		"content-service",
+		"ide-metrics-service",
+		"image-builder",
+		"messagebus-service",
+		"openvsx-proxy",
+		"proxy-caddy",
+		"public-api-server",
+		"registry-facade",
+		"server",
+		"usage",
+		"workspace",
+		"ws-daemon",
+		"ws-manager-bridge",
+		"ws-manager",
+		"ws-proxy",
+		"ws-scheduler",
+	}
+)
+
+func labels(target string) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/component": target,
+		"app.kubernetes.io/name":      App,
+		"app.kubernetes.io/part-of":   "kube-prometheus",
+	}
+}

--- a/installer/pkg/components/gitpod/networkpolicy.go
+++ b/installer/pkg/components/gitpod/networkpolicy.go
@@ -3,10 +3,11 @@ package gitpod
 import (
 	"fmt"
 
-	"github.com/gitpod-io/observability/installer/pkg/common"
 	networkv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gitpod-io/observability/installer/pkg/common"
 )
 
 func networkPolicy(target string) common.RenderFunc {
@@ -15,7 +16,7 @@ func networkPolicy(target string) common.RenderFunc {
 			&networkv1.NetworkPolicy{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "networking.k8s.io/v1",
-					Kind:       "ServiceMonitor",
+					Kind:       "NetworkPolicy",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fmt.Sprintf("%s-allow-kube-prometheus", target),

--- a/installer/pkg/components/gitpod/networkpolicy.go
+++ b/installer/pkg/components/gitpod/networkpolicy.go
@@ -1,0 +1,50 @@
+package gitpod
+
+import (
+	"fmt"
+
+	"github.com/gitpod-io/observability/installer/pkg/common"
+	networkv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func networkPolicy(target string) common.RenderFunc {
+	return func(cfg *common.RenderContext) ([]runtime.Object, error) {
+		return []runtime.Object{
+			&networkv1.NetworkPolicy{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.k8s.io/v1",
+					Kind:       "ServiceMonitor",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-allow-kube-prometheus", target),
+					Namespace: Namespace,
+					Labels:    labels(target),
+				},
+				Spec: networkv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{},
+					Ingress: []networkv1.NetworkPolicyIngressRule{
+						{
+							From: []networkv1.NetworkPolicyPeer{
+								{
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"namespace": Namespace,
+										},
+									},
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: matchLabels,
+									},
+								},
+							},
+						},
+					},
+					PolicyTypes: []networkv1.PolicyType{
+						networkv1.PolicyTypeIngress,
+					},
+				},
+			},
+		}, nil
+	}
+}

--- a/installer/pkg/components/gitpod/networkpolicy.go
+++ b/installer/pkg/components/gitpod/networkpolicy.go
@@ -23,7 +23,11 @@ func networkPolicy(target string) common.RenderFunc {
 					Labels:    labels(target),
 				},
 				Spec: networkv1.NetworkPolicySpec{
-					PodSelector: metav1.LabelSelector{},
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"component": target,
+						},
+					},
 					Ingress: []networkv1.NetworkPolicyIngressRule{
 						{
 							From: []networkv1.NetworkPolicyPeer{

--- a/installer/pkg/components/gitpod/objects.go
+++ b/installer/pkg/components/gitpod/objects.go
@@ -1,0 +1,28 @@
+package gitpod
+
+import (
+	"github.com/gitpod-io/observability/installer/pkg/common"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func generateObjects(target string) common.RenderFunc {
+	return common.CompositeRenderFunc(
+		networkPolicy(target),
+		service(target),
+		serviceMonitor(target),
+	)
+}
+
+func Objects(ctx *common.RenderContext) common.RenderFunc {
+	if !ctx.Config.Gitpod.InstallServiceMonitors {
+		return func(cfg *common.RenderContext) ([]runtime.Object, error) {
+			return []runtime.Object{}, nil
+		}
+	}
+
+	var objects common.RenderFunc
+	for _, t := range targets {
+		objects = common.CompositeRenderFunc(objects, generateObjects(t))
+	}
+	return objects
+}

--- a/installer/pkg/components/gitpod/objects.go
+++ b/installer/pkg/components/gitpod/objects.go
@@ -1,8 +1,9 @@
 package gitpod
 
 import (
-	"github.com/gitpod-io/observability/installer/pkg/common"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gitpod-io/observability/installer/pkg/common"
 )
 
 func generateObjects(target string) common.RenderFunc {

--- a/installer/pkg/components/gitpod/objects.go
+++ b/installer/pkg/components/gitpod/objects.go
@@ -20,9 +20,10 @@ func Objects(ctx *common.RenderContext) common.RenderFunc {
 		}
 	}
 
-	var objects common.RenderFunc
+	var objects []common.RenderFunc
 	for _, t := range targets {
-		objects = common.CompositeRenderFunc(objects, generateObjects(t))
+		objects = append(objects, generateObjects(t))
 	}
-	return objects
+
+	return common.CompositeRenderFunc(objects...)
 }

--- a/installer/pkg/components/gitpod/service.go
+++ b/installer/pkg/components/gitpod/service.go
@@ -2,10 +2,12 @@ package gitpod
 
 import (
 	"fmt"
-	"github.com/gitpod-io/observability/installer/pkg/common"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gitpod-io/observability/installer/pkg/common"
 )
 
 func service(target string) common.RenderFunc {

--- a/installer/pkg/components/gitpod/service.go
+++ b/installer/pkg/components/gitpod/service.go
@@ -1,0 +1,35 @@
+package gitpod
+
+import (
+	"fmt"
+	"github.com/gitpod-io/observability/installer/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func service(target string) common.RenderFunc {
+	return func(cfg *common.RenderContext) ([]runtime.Object, error) {
+		return []runtime.Object{
+			&corev1.Service{
+				TypeMeta: common.ServiceType,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-%s", App, target),
+					Namespace: Namespace,
+					Labels:    labels(target),
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name: "metrics",
+							Port: 9500,
+						},
+					},
+					Selector: map[string]string{
+						"component": target,
+					},
+				},
+			},
+		}, nil
+	}
+}

--- a/installer/pkg/components/gitpod/servicemonitor.go
+++ b/installer/pkg/components/gitpod/servicemonitor.go
@@ -1,0 +1,43 @@
+package gitpod
+
+import (
+	"fmt"
+	"github.com/gitpod-io/observability/installer/pkg/common"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func serviceMonitor(target string) common.RenderFunc {
+	return func(cfg *common.RenderContext) ([]runtime.Object, error) {
+		return []runtime.Object{
+			&monitoringv1.ServiceMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       "ServiceMonitor",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-%s", App, target),
+					Namespace: Namespace,
+					Labels:    labels(target),
+				},
+				Spec: monitoringv1.ServiceMonitorSpec{
+					Endpoints: []monitoringv1.Endpoint{
+						{
+							BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+							Interval:        "30s",
+							Port:            "metrics",
+						},
+					},
+					NamespaceSelector: monitoringv1.NamespaceSelector{
+						MatchNames: []string{Namespace},
+					},
+					Selector: metav1.LabelSelector{
+						MatchLabels: labels(target),
+					},
+				},
+			},
+		}, nil
+	}
+}

--- a/installer/pkg/components/gitpod/servicemonitor.go
+++ b/installer/pkg/components/gitpod/servicemonitor.go
@@ -2,11 +2,12 @@ package gitpod
 
 import (
 	"fmt"
-	"github.com/gitpod-io/observability/installer/pkg/common"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gitpod-io/observability/installer/pkg/common"
 )
 
 func serviceMonitor(target string) common.RenderFunc {

--- a/installer/pkg/components/werft/constants.go
+++ b/installer/pkg/components/werft/constants.go
@@ -1,0 +1,25 @@
+package werft
+
+const (
+	Namespace = "werft"
+	App       = "werft"
+	Component = "werft"
+)
+
+var (
+	matchLabels = map[string]string{
+		"app.kubernetes.io/component": "prometheus",
+		"app.kubernetes.io/instance":  "k8s",
+		"app.kubernetes.io/name":      "prometheus",
+		"app.kubernetes.io/part-of":   "kube-prometheus",
+		"app.kubernetes.io/version":   "2.37.0",
+	}
+)
+
+func labels() map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/component": Component,
+		"app.kubernetes.io/name":      App,
+		"app.kubernetes.io/part-of":   "kube-prometheus",
+	}
+}

--- a/installer/pkg/components/werft/networkpolicy.go
+++ b/installer/pkg/components/werft/networkpolicy.go
@@ -1,0 +1,48 @@
+package werft
+
+import (
+	"fmt"
+	"github.com/gitpod-io/observability/installer/pkg/common"
+
+	networkv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func networkPolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		&networkv1.NetworkPolicy{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "networking.k8s.io/v1",
+				Kind:       "ServiceMonitor",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-allow-kube-prometheus", Component),
+				Namespace: Namespace,
+				Labels:    labels(),
+			},
+			Spec: networkv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{},
+				Ingress: []networkv1.NetworkPolicyIngressRule{
+					{
+						From: []networkv1.NetworkPolicyPeer{
+							{
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"namespace": Namespace,
+									},
+								},
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: matchLabels,
+								},
+							},
+						},
+					},
+				},
+				PolicyTypes: []networkv1.PolicyType{
+					networkv1.PolicyTypeIngress,
+				},
+			},
+		},
+	}, nil
+}

--- a/installer/pkg/components/werft/networkpolicy.go
+++ b/installer/pkg/components/werft/networkpolicy.go
@@ -2,11 +2,12 @@ package werft
 
 import (
 	"fmt"
-	"github.com/gitpod-io/observability/installer/pkg/common"
 
 	networkv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gitpod-io/observability/installer/pkg/common"
 )
 
 func networkPolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
@@ -14,7 +15,7 @@ func networkPolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&networkv1.NetworkPolicy{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "networking.k8s.io/v1",
-				Kind:       "ServiceMonitor",
+				Kind:       "NetworkPolicy",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("%s-allow-kube-prometheus", Component),

--- a/installer/pkg/components/werft/objects.go
+++ b/installer/pkg/components/werft/objects.go
@@ -1,0 +1,20 @@
+package werft
+
+import (
+	"github.com/gitpod-io/observability/installer/pkg/common"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func Objects(ctx *common.RenderContext) common.RenderFunc {
+	if !ctx.Config.Werft.InstallServiceMonitors {
+		return func(cfg *common.RenderContext) ([]runtime.Object, error) {
+			return []runtime.Object{}, nil
+		}
+	}
+
+	return common.CompositeRenderFunc(
+		networkPolicy,
+		service,
+		serviceMonitor,
+	)
+}

--- a/installer/pkg/components/werft/objects.go
+++ b/installer/pkg/components/werft/objects.go
@@ -1,8 +1,9 @@
 package werft
 
 import (
-	"github.com/gitpod-io/observability/installer/pkg/common"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gitpod-io/observability/installer/pkg/common"
 )
 
 func Objects(ctx *common.RenderContext) common.RenderFunc {

--- a/installer/pkg/components/werft/service.go
+++ b/installer/pkg/components/werft/service.go
@@ -1,0 +1,33 @@
+package werft
+
+import (
+	"fmt"
+	"github.com/gitpod-io/observability/installer/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func service(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		&corev1.Service{
+			TypeMeta: common.ServiceType,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-metrics", App),
+				Namespace: Namespace,
+				Labels:    labels(),
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name: "metrics",
+						Port: 9500,
+					},
+				},
+				Selector: map[string]string{
+					"component": Component,
+				},
+			},
+		},
+	}, nil
+}

--- a/installer/pkg/components/werft/service.go
+++ b/installer/pkg/components/werft/service.go
@@ -2,10 +2,12 @@ package werft
 
 import (
 	"fmt"
-	"github.com/gitpod-io/observability/installer/pkg/common"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gitpod-io/observability/installer/pkg/common"
 )
 
 func service(ctx *common.RenderContext) ([]runtime.Object, error) {

--- a/installer/pkg/components/werft/servicemonitor.go
+++ b/installer/pkg/components/werft/servicemonitor.go
@@ -1,0 +1,39 @@
+package werft
+
+import (
+	"github.com/gitpod-io/observability/installer/pkg/common"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		&monitoringv1.ServiceMonitor{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "monitoring.coreos.com/v1",
+				Kind:       "ServiceMonitor",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      App,
+				Namespace: Namespace,
+				Labels:    labels(),
+			},
+			Spec: monitoringv1.ServiceMonitorSpec{
+				Endpoints: []monitoringv1.Endpoint{
+					{
+						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+						Interval:        "30s",
+						Port:            "metrics",
+					},
+				},
+				NamespaceSelector: monitoringv1.NamespaceSelector{
+					MatchNames: []string{Namespace},
+				},
+				Selector: metav1.LabelSelector{
+					MatchLabels: labels(),
+				},
+			},
+		},
+	}, nil
+}

--- a/installer/pkg/components/werft/servicemonitor.go
+++ b/installer/pkg/components/werft/servicemonitor.go
@@ -1,10 +1,11 @@
 package werft
 
 import (
-	"github.com/gitpod-io/observability/installer/pkg/common"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gitpod-io/observability/installer/pkg/common"
 )
 
 func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {

--- a/installer/pkg/config/config.go
+++ b/installer/pkg/config/config.go
@@ -29,6 +29,10 @@ func Defaults(in interface{}) error {
 		Install: false,
 	}
 
+	cfg.Prometheus = &Prometheus{
+		RemoteWrite: []*RemoteWrite{},
+	}
+
 	cfg.Pyrra = &Pyrra{
 		Install: false,
 	}


### PR DESCRIPTION
## Description
Wrapper functions for generating all the components for prometheus metrics

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
