### PR TITLE
Add script to compare renderings of Go and Jsonnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ config.yaml
 
 .idea
 ./kind
+
+diff

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,8 +1,9 @@
 image: gitpod/workspace-full:2022-08-04-13-40-17
 workspaceLocation: observability/observability.code-workspace
 tasks:
-  - init: |
-      # TODO(arthursens): We should update the workspace image so we dont need the step below
+  - command: |
+      # TODO(arthursens): We should update the workspace image so we dont need the steps below
+      sudo curl -Lo /usr/bin/yq https://github.com/mikefarah/yq/releases/download/v4.27.2/yq_linux_amd64 && sudo chmod +x /usr/bin/yq
       sudo apt update ; sudo apt-get install shellcheck apt-transport-https ca-certificates -y ; sudo update-ca-certificates
       make --always-make
       pip install pre-commit && pre-commit install --install-hooks

--- a/diff-satellite.sh
+++ b/diff-satellite.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+
+# Make sure to use project tooling
+PATH="$(pwd)/tmp/bin:${PATH}"
+
+
+[[ ! -e diff ]] || rm -rf diff
+
+# Generate monitoring-satellite YAML files
+jsonnet -c -J vendor -m diff/jsonnet-tmp \
+--ext-code config="{
+    namespace: 'monitoring-satellite',
+    clusterName: 'fake-cluster',
+    alerting: {
+        pagerdutyRoutingKey: 'pd-routing-key',
+        slackOAuthToken: 'fake-key',
+
+        ide: {},
+        webapp: {},
+        platform: {},
+        workspace: {},
+
+        generic: {
+            slackChannel: '#a_generic_channel',
+        }
+    },
+    tracing: {
+        honeycombAPIKey: 'fake-key',
+        honeycombDataset: 'fake-dataset',
+    },
+    prometheus: {
+        externalLabels: {
+            environment: 'test',
+        },
+        DNS: 'prometheus.fake.dns.com',
+        nodePort: 32164,
+        GCPExternalIpAddress: 'external-ip-name',
+        BasicAuthSecretBase64: 'NGI5ZDlmOTQ3MTU1ODFmZWQwYzc6JGFwcjEkdDd5V2IxcXUkMU9na21JMzB4RW5SNHRiQUkwaFF5MA==',
+        enableFeatures: ['remote-write-receiver'],
+    },
+    remoteWrite: {
+        username: 'user',
+        password: 'p@ssW0rd',
+        urls: ['http://victoriametrics.monitoring-central.svc:8480/insert/0/prometheus'],
+        writeRelabelConfigs: [
+          {
+            sourceLabels: ['__name__'],
+            targetLabel: '__name__',
+            regex: 'up',
+            action: 'replace',
+            replacement: 'relabeled_up'
+          }
+        ],
+    },
+    previewEnvironment: {
+        nodeExporterPort: 9100
+    },
+    nodeAffinity: {
+        nodeSelector: {
+            nodepool: 'monitoring',
+            'kubernetes.io/os': 'linux',
+        },
+    },
+    werft: {
+        namespace: 'werft',
+    },
+    stackdriver: {
+        clientEmail: 'fake@email.com',
+        defaultProject: 'google-project',
+        privateKey: 
+|||
+  multiline
+  fake
+  key
+|||,
+    },
+    kubescape: {},
+    pyrra: {},
+    probe: {
+        targets: ['http://google.com'],
+    },
+}" \
+monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml >> diff/jsonnet-unsorted.yaml; echo "---" >> diff/jsonnet-unsorted.yaml' -- {}
+rm -rf diff/jsonnet-tmp
+
+function normalize() {
+    IN=$1
+    OUT=$2
+
+    # ensure directory exists and is empty
+    [[ ! -e "$OUT" ]] || rm -rf "$OUT"
+    mkdir -p "$OUT"
+
+    # iterate through all documents from the YAML
+    documentIndex=0
+    while [ ! -z $(yq e "select(documentIndex == $documentIndex) | .apiVersion" $IN) ]; do
+
+        # extract the component name from the label. If the label is not set, the result will be 'null'.
+        COMP=$(yq e "select(documentIndex == $documentIndex) | .metadata.labels.\"app.kubernetes.io/component\"" $IN)
+        TMP="$OUT/$COMP.tmp"
+
+        # add a YAML document separator ("---") to the file if the file already exists.
+        [[ ! -e "$TMP" ]] || echo "---" >> "$TMP"
+
+        # extract the document from the large input file and append it to the file that's named after the component.
+        yq e "select(documentIndex == $documentIndex)" $IN >> "$TMP"
+
+        documentIndex=$((documentIndex + 1))
+    done
+
+    # sort the documents in the YAML by .kind (first) and .metadata.name. (second)
+    for I in `find $OUT -iname *.tmp`; do
+        yq ea '[.] | sort_by(.kind + .metadata.name) | .[] | splitDoc' $I > ${I/tmp/yaml}
+    done
+
+    # delete TMP files.
+    rm $OUT/*.tmp
+}
+
+normalize diff/jsonnet-unsorted.yaml diff/jsonnet
+
+#####  go-based installer
+
+(cd installer/; go run main.go render -c - <<< "
+alerting:
+  config: {}
+gitpod:
+  installServiceMonitors: true
+namespace: monitoring-satellite
+prober:
+  install: false
+pyrra:
+  install: false
+tracing:
+  install: false
+werft:
+  installServiceMonitors: false
+prometheus:
+  enableFeatures: 
+    - foo
+") > diff/go-unsorted.yaml
+
+normalize diff/go-unsorted.yaml diff/go


### PR DESCRIPTION
## Description
Before shipping the obs installer, we must ensure the rendered YAML is accurate. 
While we can simply run the observability stack - it will be a lot of work to track every failure down to that line of YAML which is broken. 

A more efficient way of finding mistakes is to compare the rendering of the obs installer with the rendering of Jsonnet. 

To make YAML comparable, it must be 
* normalized into a structure that's independent of the rendered implementaiton. 
* split into chunks that are easy to work with.

This PR adds a little script to make this easier.

For each Go and Jsonnet, the script
1. renders the YAML and splits it into separate files based on the `app.kubernetes.io/component` label. 
2. Sorts every file based on `kind` (e.g. Deployment, StatefulSet) and `name`.

## Watch it in action

See this [Loom Video](https://www.loom.com/share/732938a5ef764e3f9c8326216b2c1c0f).

## How to test
run `./diff-sattelite.sh`

