### PR TITLE
End-to-end tests for the CLI installer

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -3,6 +3,7 @@ on:
   - push
 env:
   golang-version: "1.18"
+  kind-version: "v0.11.1"
 jobs:
   go:
     runs-on: ubuntu-latest
@@ -13,3 +14,35 @@ jobs:
         with:
           go-version: ${{ env.golang-version }}
       - run: cd installer && make build && git diff --exit-code
+  e2e-tests:
+    name: E2E tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        kind-image:
+          - "kindest/node:v1.21.1"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.golang-version }}
+      - name: Start KinD
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: ${{ env.kind-version }}
+          image: ${{ matrix.kind-image }}
+          wait: 300s
+      - name: Wait for cluster to finish bootstraping
+        run: kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
+      - name: Create monitoring-satellite
+        run: |
+          make generate
+          ./hack/deploy-crds.sh
+          cd installer && make apply-satellite
+      - name: Run tests
+        run: |
+          export KUBECONFIG="${HOME}/.kube/config"
+          make test-e2e
+

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,12 @@ deploy-satellite: generate
 	./hack/prepare-kind.sh
 	./hack/deploy-satellite.sh
 
+.PHONY: deploy-satellite-go
+deploy-satellite-go: generate
+	./hack/prepare-kind.sh
+	./hack/deploy-crds.sh
+	@cd installer && $(MAKE) apply-satellite
+
 .PHONY: deploy-central
 deploy-central: generate
 	./hack/prepare-kind.sh

--- a/hack/deploy-crds.sh
+++ b/hack/deploy-crds.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+KUBECONFIG=""
+KUBECONFIG_FLAG=""
+
+opts=$(getopt \
+  --longoptions "kubeconfig:" \
+  --name "$(basename "$0")" \
+  --options "" \
+  -- "$@"
+)
+
+eval set -- "$opts"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --kubeconfig) KUBECONFIG=$2 ; shift 2 ;;
+    *) break ;;
+  esac
+done
+
+if [[ $KUBECONFIG != "" ]]; then
+  KUBECONFIG_FLAG="--kubeconfig ${KUBECONFIG}"
+fi
+
+for CRD in $(find monitoring-satellite/manifests/prometheusOperator/ -type f -name "*CustomResourceDefinition.yaml"); 
+do 
+  kubectl $KUBECONFIG_FLAG replace -f $CRD || kubectl $KUBECONFIG_FLAG create -f $CRD
+done
+
+until kubectl $KUBECONFIG_FLAG get servicemonitors.monitoring.coreos.com --all-namespaces ; do date; sleep 1; echo ""; done
+until kubectl $KUBECONFIG_FLAG get prometheusrules.monitoring.coreos.com --all-namespaces ; do date; sleep 1; echo ""; done
+
+kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/pyrra/crd.yaml

--- a/hack/deploy-satellite.sh
+++ b/hack/deploy-satellite.sh
@@ -26,15 +26,7 @@ fi
 kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/namespace.yaml
 kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/podsecuritypolicy-restricted.yaml
 
-for CRD in $(find monitoring-satellite/manifests/prometheusOperator/ -type f -name "*CustomResourceDefinition.yaml"); 
-do 
-  kubectl $KUBECONFIG_FLAG replace -f $CRD || kubectl $KUBECONFIG_FLAG create -f $CRD
-done
-
-until kubectl $KUBECONFIG_FLAG get servicemonitors.monitoring.coreos.com --all-namespaces ; do date; sleep 1; echo ""; done
-until kubectl $KUBECONFIG_FLAG get prometheusrules.monitoring.coreos.com --all-namespaces ; do date; sleep 1; echo ""; done
-
-kubectl $KUBECONFIG_FLAG apply -f monitoring-satellite/manifests/pyrra/crd.yaml
+./hack/deploy-crds.sh --kubeconfig $KUBECONFIG
 
 for operatorManifest in $(find monitoring-satellite/manifests/prometheusOperator/ -type f ! -name "*CustomResourceDefinition.yaml"); 
 do 

--- a/hack/prepare-kind.sh
+++ b/hack/prepare-kind.sh
@@ -9,8 +9,8 @@ if [[ $? != 0 ]]; then
     | cut -d : -f 2,3 \
     | tr -d \" \
     | wget -qi -
-    mv kind-linux-amd64 tmp/bin/kind && chmod +x tmp/bin/kind
-    export PATH=$PATH:$(pwd)/tmp/bin
+    sudo mv kind-linux-amd64 /usr/bin/kind && sudo chmod +x /usr/bin/kind
+    rm -f kind-linux-amd64*
 fi
 
 cluster_created=$(kind get clusters 2>&1)

--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -1,1 +1,3 @@
 installer
+monitoring-satellite.yaml 
+config.yaml

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -1,4 +1,6 @@
-all: build
+all: installer monitoring-satellite.yaml
+
+installer: build
 
 build: lint
 	CGO_ENABLED=0 go build .
@@ -13,3 +15,14 @@ fmt:
 # Run go vet against code
 vet:
 	go vet ./...
+
+monitoring-satellite.yaml: generate
+
+generate: installer
+	./installer init > config.yaml
+	./installer render --config config.yaml > monitoring-satellite.yaml
+
+.PHONY: deploy-satellite
+apply-satellite: monitoring-satellite.yaml
+	kubectl create ns monitoring-satellite || true
+	kubectl apply -f monitoring-satellite.yaml

--- a/installer/pkg/common/types.go
+++ b/installer/pkg/common/types.go
@@ -12,7 +12,7 @@ var (
 		Kind:       "Deployment",
 	}
 	ServiceType = metav1.TypeMeta{
-		APIVersion: "apps/v1",
+		APIVersion: "v1",
 		Kind:       "Service",
 	}
 )

--- a/installer/pkg/components/alertmanager/serviceaccount.go
+++ b/installer/pkg/components/alertmanager/serviceaccount.go
@@ -11,7 +11,7 @@ func serviceAccount(ctx *common.RenderContext) ([]runtime.Object, error) {
 	return []runtime.Object{
 		&corev1.ServiceAccount{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "apps/v1",
+				APIVersion: "v1",
 				Kind:       "ServiceAccount",
 			},
 			ObjectMeta: metav1.ObjectMeta{

--- a/installer/pkg/components/prometheusOperator/service.go
+++ b/installer/pkg/components/prometheusOperator/service.go
@@ -12,7 +12,7 @@ func service(ctx *common.RenderContext) ([]runtime.Object, error) {
 	return []runtime.Object{
 		&corev1.Service{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "apps/v1",
+				APIVersion: "v1",
 				Kind:       "Service",
 			},
 			ObjectMeta: metav1.ObjectMeta{

--- a/installer/pkg/components/prometheusOperator/serviceaccount.go
+++ b/installer/pkg/components/prometheusOperator/serviceaccount.go
@@ -11,7 +11,7 @@ func serviceAccount(ctx *common.RenderContext) ([]runtime.Object, error) {
 	return []runtime.Object{
 		&corev1.ServiceAccount{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "apps/v1",
+				APIVersion: "v1",
 				Kind:       "ServiceAccount",
 			},
 			ObjectMeta: metav1.ObjectMeta{

--- a/installer/pkg/components/pyrra/clusterrole.go
+++ b/installer/pkg/components/pyrra/clusterrole.go
@@ -64,7 +64,7 @@ func clusterRoleBinding(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&rbacv1.ClusterRoleBinding{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "rbac.authorization.k8s.io/v1",
-				Kind:       "ClusterRole",
+				Kind:       "ClusterRoleBinding",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      componentName(kubernetesComponent),

--- a/installer/pkg/components/pyrra/deployment.go
+++ b/installer/pkg/components/pyrra/deployment.go
@@ -1,6 +1,8 @@
 package pyrra
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +27,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&appsv1.Deployment{
 			TypeMeta: common.DeploymentType,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Name,
+				Name:      fmt.Sprintf("%s-%s", Name, "api"),
 				Namespace: Namespace,
 				Labels:    pyrraLabels(apiComponent),
 			},
@@ -64,7 +66,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		&appsv1.Deployment{
 			TypeMeta: common.DeploymentType,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Name,
+				Name:      fmt.Sprintf("%s-%s", Name, "kubernetes"),
 				Namespace: Namespace,
 				Labels:    pyrraLabels(kubernetesComponent),
 			},

--- a/installer/pkg/components/pyrra/serviceaccount.go
+++ b/installer/pkg/components/pyrra/serviceaccount.go
@@ -11,7 +11,7 @@ func serviceAccount(ctx *common.RenderContext) ([]runtime.Object, error) {
 	return []runtime.Object{
 		&corev1.ServiceAccount{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "apps/v1",
+				APIVersion: "v1",
 				Kind:       "ServiceAccount",
 			},
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This PR adds a new job that:
1. Render the default manifests
2. Apply it to a cluster
3. Run the same tests we have for our jsonnet setup.


I've also made some changes so we can at least apply the manifests successfully, but the tests that verify that the stack is running as expected are failing.

For this PR I'm not aiming to fix everything, but just to have e2e tests. We can (and need) to fix everything at some point this week though