### PR TITLE
Refactor CLI installer config struct to reflect jsonnet's

### DIFF
--- a/installer/pkg/common/render.go
+++ b/installer/pkg/common/render.go
@@ -6,6 +6,7 @@ package common
 
 import (
 	"fmt"
+
 	"github.com/docker/distribution/reference"
 	"github.com/gitpod-io/observability/installer/pkg/config"
 	"helm.sh/helm/v3/pkg/cli/values"

--- a/installer/pkg/components/alertmanager/alertmanager.go
+++ b/installer/pkg/components/alertmanager/alertmanager.go
@@ -26,7 +26,7 @@ func alertmanager(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Labels:    common.Labels(Name, Component, App, Version),
 			},
 			Spec: monitoringv1.AlertmanagerSpec{
-				Image: pointer.String(common.ImageName(ctx.Config.Components.AlertManager.Repository, ctx.Config.Components.AlertManager.Version)),
+				Image: pointer.String(fmt.Sprintf("%s:v%s", ImageURL, Version)),
 				PodMetadata: &monitoringv1.EmbeddedObjectMetadata{
 					Labels: common.Labels(Name, Component, App, Version),
 				},

--- a/installer/pkg/components/kubestate-metrics/deployment.go
+++ b/installer/pkg/components/kubestate-metrics/deployment.go
@@ -2,6 +2,7 @@ package kubestateMetrics
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/gitpod-io/observability/installer/pkg/common"
@@ -75,7 +76,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Containers: []corev1.Container{
 							{
 								Name:            Name,
-								Image:           common.ImageName(ctx.Config.Components.KubeStateMetrics.Repository, ctx.Config.Components.KubeStateMetrics.Version),
+								Image:           fmt.Sprintf("%s:v%s", ImageURL, Version),
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Args: []string{
 									"--host=127.0.0.1",

--- a/installer/pkg/components/node-exporter/daemonset.go
+++ b/installer/pkg/components/node-exporter/daemonset.go
@@ -1,6 +1,8 @@
 package nodeExporter
 
 import (
+	"fmt"
+
 	"github.com/gitpod-io/observability/installer/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -87,7 +89,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 									"--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15})$",
 									"--collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15})$",
 								},
-								Image: common.ImageName(ctx.Config.Components.NodeExporter.Repository, ctx.Config.Components.NodeExporter.Version),
+								Image: fmt.Sprintf("%s:v%s", ImageURL, Version),
 								Name:  Name,
 								Resources: v1.ResourceRequirements{
 									Requests: v1.ResourceList{

--- a/installer/pkg/components/otel-collector/deployment.go
+++ b/installer/pkg/components/otel-collector/deployment.go
@@ -1,6 +1,8 @@
 package otelCollector
 
 import (
+	"fmt"
+
 	"github.com/gitpod-io/observability/installer/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,7 +32,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						ServiceAccountName: Name,
 						Containers: []corev1.Container{{
 							Name:            Name,
-							Image:           common.ImageName(ctx.Config.Components.OtelCollector.Repository, ctx.Config.Components.OtelCollector.Version),
+							Image:           fmt.Sprintf("%s:%s", ImageURL, Version),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args: []string{
 								"--config=/conf/collector.yaml",

--- a/installer/pkg/components/probers/deployment.go
+++ b/installer/pkg/components/probers/deployment.go
@@ -1,6 +1,8 @@
 package probers
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +32,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{
 							Name:            Name,
-							Image:           common.ImageName(ctx.Config.Components.Probers.Repository, ctx.Config.Components.Probers.Version),
+							Image:           fmt.Sprintf("%s:v%s", ImageURL, Version),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 						}},
 						NodeSelector: map[string]string{

--- a/installer/pkg/components/prometheusOperator/deployment.go
+++ b/installer/pkg/components/prometheusOperator/deployment.go
@@ -37,7 +37,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						AutomountServiceAccountToken: pointer.Bool(true),
 						Containers: []corev1.Container{{
 							Name:            Name,
-							Image:           common.ImageName(ctx.Config.Components.PrometheusOperator.Repository, ctx.Config.Components.PrometheusOperator.Version),
+							Image:           fmt.Sprintf("%s:v%s", ImageURL, Version),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args: []string{
 								"--kubelet-service=kube-system/kubelet",

--- a/installer/pkg/components/pyrra/deployment.go
+++ b/installer/pkg/components/pyrra/deployment.go
@@ -1,6 +1,8 @@
 package pyrra
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,7 +44,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{
 							Name:            Name,
-							Image:           common.ImageName(ctx.Config.Components.Pyrra.Repository, ctx.Config.Components.Pyrra.Version),
+							Image:           fmt.Sprintf("%s:v%s", ImageURL, Version),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args: []string{
 								"api",
@@ -82,7 +84,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						ServiceAccountName: "pyrra-kubernetes",
 						Containers: []corev1.Container{{
 							Name:            Name,
-							Image:           common.ImageName(ctx.Config.Components.Pyrra.Repository, ctx.Config.Components.Pyrra.Version),
+							Image:           fmt.Sprintf("%s:v%s", ImageURL, Version),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args:            []string{"kubernetes"},
 							Ports: []corev1.ContainerPort{{


### PR DESCRIPTION
This PR refactors the `Config` struct to **_almost_** to reflect what we currently have with our Jsonnet configuration surface.

The changes made are:

1. `remoteWrite` was moved inside the `Prometheus` struct
<details><summary>RemoteWrite difference</summary>

Before:
```jsonnet
{
  remoteWrite: {
    username: 'user',
    password: 'password',
    ...
  }
  prometheus: ...
}
```

Now:
```yaml
prometheus:
    remoteWrite: 
    - username: 'user'
      password: 'password'
      url: example.com
    - username: 'user-for-second-remotewrite-url'
      ...
```

</details>

2. Alerting now accepts the whole Alertmanager configuration as part of the configuration YAML. The main point is because our logic is waaaaay too complex now, it is easier to just pass the right configuration 😅.

3. I haven't added the Stackdriver configuration, used by jsoonnet today to configure the Stackdrive datasource in Grafana. The reason is that how we will handle Grafana isn't clear yet 😬 