### PR TITLE
Add default-container annotation to kube-state-metrics

### DIFF
--- a/installer/pkg/components/kubestate-metrics/deployment.go
+++ b/installer/pkg/components/kubestate-metrics/deployment.go
@@ -62,6 +62,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: common.Labels(Name, Component, App, Version),
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "kube-state-metrics",
+						},
 					},
 					Spec: corev1.PodSpec{
 						ServiceAccountName:           Name,


### PR DESCRIPTION
Fix diff in[ kube-state-metrics deployment](https://argo-cd.gitpod-io-dev.com/applications/stag-meta-us02-monitoring-satellite?conditions=false&resource=sync%3AOutOfSync%2Cname%3Akube-state-metrics&node=apps%2FDeployment%2Fmonitoring-satellite%2Fkube-state-metrics)

![image](https://user-images.githubusercontent.com/24193764/184409189-43b8aaa3-ff21-4550-afa7-84f6f603f3dc.png)
