### PR TITLE
Add prometheus-operator default container annotation

### DIFF
--- a/installer/pkg/components/prometheus-operator/deployment.go
+++ b/installer/pkg/components/prometheus-operator/deployment.go
@@ -31,6 +31,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: common.Labels(Name, Component, App, Version),
+						Annotations: map[string]string{
+							"kubectl.kubernetes.io/default-container": "prometheus-operator",
+						},
 					},
 					Spec: corev1.PodSpec{
 						NodeSelector:                 ctx.Config.NodeSelector,


### PR DESCRIPTION
Add missing default-container annotation for prometheus-operator

![image](https://user-images.githubusercontent.com/24193764/184410183-ca991c79-a89c-4ca4-847d-c4da118d0f8c.png)
