### PR TITLE
Fix namespace where gitpod monitoring resource are deployed to

### DIFF
--- a/installer/pkg/components/gitpod/constants.go
+++ b/installer/pkg/components/gitpod/constants.go
@@ -1,8 +1,9 @@
 package gitpod
 
 const (
-	Namespace = "monitoring-satellite"
-	App       = "gitpod"
+	GitpodNamespace = "default"
+	Namespace       = "monitoring-satellite"
+	App             = "gitpod"
 )
 
 var (

--- a/installer/pkg/components/gitpod/networkpolicy.go
+++ b/installer/pkg/components/gitpod/networkpolicy.go
@@ -20,7 +20,7 @@ func networkPolicy(target string) common.RenderFunc {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fmt.Sprintf("%s-allow-kube-prometheus", target),
-					Namespace: Namespace,
+					Namespace: GitpodNamespace,
 					Labels:    labels(target),
 				},
 				Spec: networkv1.NetworkPolicySpec{

--- a/installer/pkg/components/gitpod/service.go
+++ b/installer/pkg/components/gitpod/service.go
@@ -17,7 +17,7 @@ func service(target string) common.RenderFunc {
 				TypeMeta: common.ServiceType,
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fmt.Sprintf("%s-%s", App, target),
-					Namespace: Namespace,
+					Namespace: GitpodNamespace,
 					Labels:    labels(target),
 				},
 				Spec: corev1.ServiceSpec{

--- a/installer/pkg/components/gitpod/servicemonitor.go
+++ b/installer/pkg/components/gitpod/servicemonitor.go
@@ -32,7 +32,7 @@ func serviceMonitor(target string) common.RenderFunc {
 						},
 					},
 					NamespaceSelector: monitoringv1.NamespaceSelector{
-						MatchNames: []string{Namespace},
+						MatchNames: []string{GitpodNamespace},
 					},
 					Selector: metav1.LabelSelector{
 						MatchLabels: labels(target),


### PR DESCRIPTION
The namespace where NetworkPolicies and Services used to monitor Gitpod is the same where the components live.

This PR makes this adjustment