### PR TITLE
Remove servicemonitor and rule monitor selector

### DIFF
--- a/installer/pkg/components/prometheus/prometheus.go
+++ b/installer/pkg/components/prometheus/prometheus.go
@@ -51,21 +51,12 @@ func prometheus(ctx *common.RenderContext) ([]runtime.Object, error) {
 					RunAsNonRoot: pointer.Bool(true),
 				},
 				ServiceAccountName: fmt.Sprintf("prometheus-%s", Name),
-				ServiceMonitorNamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"kubernetes.io/metadata.name": Namespace,
-					},
-				},
-				ExternalLabels: ctx.Config.Prometheus.ExternalLabels,
-				EnableFeatures: ctx.Config.Prometheus.EnableFeatures,
-				Resources:      ctx.Config.Prometheus.Resources,
-				NodeSelector:   ctx.Config.NodeSelector,
-				RemoteWrite:    remoteWriteSpecs(ctx),
-			},
-			RuleNamespaceSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"kubernetes.io/metadata.name": Namespace,
-				},
+				ExternalLabels:     ctx.Config.Prometheus.ExternalLabels,
+				EnableFeatures:     ctx.Config.Prometheus.EnableFeatures,
+				Resources:          ctx.Config.Prometheus.Resources,
+				NodeSelector:       ctx.Config.NodeSelector,
+				RemoteWrite:        remoteWriteSpecs(ctx),
+				Version:            Version,
 			},
 		},
 	})


### PR DESCRIPTION
Probably the reason for #232, but would like to close the issue after testing it properly.

Right now this PR is fixing [the current diff](https://argo-cd.gitpod-io-dev.com/applications/stag-meta-us02-monitoring-satellite?resource=kind%3APrometheus&conditions=false&node=monitoring.coreos.com%2FPrometheus%2Fmonitoring-satellite%2Fk8s):

![image](https://user-images.githubusercontent.com/24193764/184417514-5f4d8fac-9a44-49b3-85d0-6791b64e5e46.png)
