### PR TITLE
Fix Gitpod PrometheusRule name

### DIFF
--- a/installer/pkg/importer/mixin.go
+++ b/installer/pkg/importer/mixin.go
@@ -94,7 +94,7 @@ func unmarshalMixinToRuntimeObject(j string) []runtime.Object {
 				Kind:       "PrometheusRule",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "gitpod-monitoring",
+				Name: "gitpod-monitoring-rules",
 				//TODO: get namespace from config
 				Namespace: "monitoring-satellite",
 			},


### PR DESCRIPTION
It is super hard to check the rules difference at the moment because we're changing the object name:

![image](https://user-images.githubusercontent.com/24193764/184418521-1d1efa7d-1a56-44b0-ba02-a0105b2b8aad.png)
