### PR TITLE
Change shared psp name to the same used in jsonnet

### DIFF
--- a/installer/pkg/components/shared/restrictedPodSecurityPolicy.go
+++ b/installer/pkg/components/shared/restrictedPodSecurityPolicy.go
@@ -59,5 +59,5 @@ func restrictedPodsecurityPolicy(ctx *common.RenderContext) ([]runtime.Object, e
 }
 
 func RestrictedPodsecurityPolicyName() string {
-	return "restricted-psp"
+	return "kube-prometheus-restricted"
 }


### PR DESCRIPTION
Some components imported from YAML are using the restricted podsecuritypolicy generated by jsonnet. 

To make a friendlier transition we could at least keep the same name, and replace it when it is more convenient

![image](https://user-images.githubusercontent.com/24193764/184419554-d442e424-91c5-4257-9c08-8c6f71a8133b.png)
![image](https://user-images.githubusercontent.com/24193764/184419572-1fc6c606-36a2-4af0-afcd-1dfe808bdc65.png)
