### PR TITLE
Update part-of label to same as jsonnet

### DIFF
--- a/installer/pkg/components/alertmanager/constants.go
+++ b/installer/pkg/components/alertmanager/constants.go
@@ -4,7 +4,7 @@ import "fmt"
 
 const (
 	Name      = "main"
-	App       = "monitoring-satellite"
+	App       = "kube-prometheus"
 	Version   = "0.24.0"
 	Namespace = "monitoring-satellite"
 	ImageURL  = "quay.io/prometheus/alertmanager"

--- a/installer/pkg/components/node-exporter/constants.go
+++ b/installer/pkg/components/node-exporter/constants.go
@@ -2,7 +2,7 @@ package nodeexporter
 
 const (
 	Name      = "node-exporter"
-	App       = "monitoring-satellite"
+	App       = "kube-prometheus"
 	Version   = "1.3.1"
 	Namespace = "monitoring-satellite"
 	ImageURL  = "quay.io/prometheus/node-exporter"

--- a/installer/pkg/components/prometheus-operator/constants.go
+++ b/installer/pkg/components/prometheus-operator/constants.go
@@ -2,7 +2,7 @@ package prometheusoperator
 
 const (
 	Name      = "prometheus-operator"
-	App       = "monitoring-satellite"
+	App       = "kube-prometheus"
 	Version   = "0.58.0"
 	Namespace = "monitoring-satellite"
 	ImageURL  = "quay.io/prometheus-operator/prometheus-operator"

--- a/installer/pkg/components/prometheus/constants.go
+++ b/installer/pkg/components/prometheus/constants.go
@@ -4,7 +4,7 @@ import "fmt"
 
 const (
 	Name      = "k8s"
-	App       = "monitoring-satellite"
+	App       = "kube-prometheus"
 	Version   = "2.37.0"
 	Namespace = "monitoring-satellite"
 	ImageURL  = "quay.io/prometheus/prometheus"


### PR DESCRIPTION
Getting every single label equal to what we have in jsonnet doesn't bring value and it's way too much work.

The `app.kubernetes.io/part-of` is currently inconsistent though, some components have it set to `kube-prometheus` and others to `monitoring-satellite`. Let's at least on this one get it equal to what we have in jsonnet and in the future we can decide on what should be its content
![image](https://user-images.githubusercontent.com/24193764/184450090-de9a43d4-2a3a-4fc4-97d2-d7c0b9342549.png)
