### PR TITLE
Use kind config file in CI

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -34,6 +34,7 @@ jobs:
           version: ${{ env.kind-version }}
           image: ${{ matrix.kind-image }}
           wait: 300s
+          config: .github/workflows/kind/config.yml
       - name: Wait for cluster to finish bootstraping
         run: kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
       - name: Create monitoring-satellite


### PR DESCRIPTION
All deployments are getting ready in CI, except for grafana. The problem is that grafana has a nodeselector because the same YAML used in CI is also used in our experiment in staging.

We have a kind config file that adds the necessary node label used by Grafana's node selector, but we never used this file during CI. This PR updates the CI to use that config file.


---

You can verify that now the test that verify Grafana is up and running is now passing.