### PR TITLE
Fix messagebus monitoring resources

### DIFF
--- a/installer/pkg/components/gitpod/constants.go
+++ b/installer/pkg/components/gitpod/constants.go
@@ -21,7 +21,6 @@ var (
 		"content-service",
 		"ide-metrics",
 		"image-builder-mk3",
-		"messagebus",
 		"openvsx-proxy",
 		"public-api-server",
 		"registry-facade",

--- a/installer/pkg/components/gitpod/messagebus.go
+++ b/installer/pkg/components/gitpod/messagebus.go
@@ -1,0 +1,104 @@
+package gitpod
+
+import (
+	"fmt"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gitpod-io/observability/installer/pkg/common"
+)
+
+func messagebusObjects() common.RenderFunc {
+	return func(ctx *common.RenderContext) ([]runtime.Object, error) {
+		return []runtime.Object{
+			&networkv1.NetworkPolicy{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "networking.k8s.io/v1",
+					Kind:       "NetworkPolicy",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-allow-kube-prometheus", "messagebus"),
+					Namespace: GitpodNamespace,
+					Labels:    labels("messagebus"),
+				},
+				Spec: networkv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"component": "messagebus",
+						},
+					},
+					Ingress: []networkv1.NetworkPolicyIngressRule{
+						{
+							From: []networkv1.NetworkPolicyPeer{
+								{
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"namespace": Namespace,
+										},
+									},
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: matchLabels,
+									},
+								},
+							},
+						},
+					},
+					PolicyTypes: []networkv1.PolicyType{
+						networkv1.PolicyTypeIngress,
+					},
+				},
+			},
+
+			&corev1.Service{
+				TypeMeta: common.ServiceType,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-%s", App, "messagebus"),
+					Namespace: GitpodNamespace,
+					Labels:    labels("messagebus"),
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name: "metrics",
+							Port: 9419,
+						},
+					},
+					Selector: map[string]string{
+						"app.kubernetes.io/name": "rabbitmq",
+					},
+				},
+			},
+			&monitoringv1.ServiceMonitor{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "monitoring.coreos.com/v1",
+					Kind:       "ServiceMonitor",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-%s", App, "messagebus"),
+					Namespace: Namespace,
+					Labels:    labels("messagebus"),
+				},
+				Spec: monitoringv1.ServiceMonitorSpec{
+					Endpoints: []monitoringv1.Endpoint{
+						{
+							BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+							Interval:        "30s",
+							Port:            "metrics",
+						},
+					},
+					JobLabel: "app.kubernetes.io/component",
+					NamespaceSelector: monitoringv1.NamespaceSelector{
+						MatchNames: []string{GitpodNamespace},
+					},
+					Selector: metav1.LabelSelector{
+						MatchLabels: labels("messagebus"),
+					},
+				},
+			},
+		}, nil
+	}
+}

--- a/installer/pkg/components/gitpod/objects.go
+++ b/installer/pkg/components/gitpod/objects.go
@@ -26,7 +26,12 @@ func Objects(ctx *common.RenderContext) common.RenderFunc {
 		objects = append(objects, generateObjects(t))
 	}
 
-	objects = append(objects, podMonitor(), proxyCaddyObjects())
+	objects = append(
+		objects,
+		podMonitor(),
+		proxyCaddyObjects(),
+		messagebusObjects(),
+	)
 
 	return common.CompositeRenderFunc(objects...)
 }


### PR DESCRIPTION
Messagebus doesn't follow the pattern of using port 9500 as its metrics endpoint. This PR removes it from using the boilerplated resources and creates its own for messagebus

![image](https://user-images.githubusercontent.com/24193764/184650465-23c0b16c-225d-4fb4-9dbf-9e480b3f1387.png)
