### PR TITLE
Re-add network policies to allow workspace scraping

### DIFF
--- a/installer/pkg/components/gitpod/objects.go
+++ b/installer/pkg/components/gitpod/objects.go
@@ -28,7 +28,7 @@ func Objects(ctx *common.RenderContext) common.RenderFunc {
 
 	objects = append(
 		objects,
-		podMonitor(),
+		workspaceObjects(),
 		proxyCaddyObjects(),
 		messagebusObjects(),
 	)


### PR DESCRIPTION
While working on https://github.com/gitpod-io/observability/pull/242, I accidentally removed a NetworkPolicy that shouldn't be removed

![image](https://user-images.githubusercontent.com/24193764/184652555-d03d53a8-118d-42f9-a7d4-5a59139d05b7.png)
