### PR TITLE
Import upstream Prometheus Rules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: peimanja/promtool-github-actions@master
         with:
           promtool_actions_subcommand: "rules"
-          promtool_actions_files: "monitoring-satellite/manifests/ci_prometheus_rules.yaml"
+          promtool_actions_files: "monitoring-satellite/manifests/kube-prometheus-rules/rules.yaml"
           promtool_actions_comment: true
           promtool_actions_version: "2.26.0"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,20 +13,6 @@ jobs:
       - uses: actions/checkout@v2
       - run: make --always-make fmt && git diff --exit-code
 
-  promtool-lint:
-    runs-on: ubuntu-latest
-    name: Prometheus alerts and recording rules linter
-    steps:
-      - uses: actions/checkout@v2
-      - run: make --always-make generate
-      - name: Check Prometheus alert rules
-        uses: peimanja/promtool-github-actions@master
-        with:
-          promtool_actions_subcommand: "rules"
-          promtool_actions_files: "monitoring-satellite/manifests/kube-prometheus-rules/rules.yaml"
-          promtool_actions_comment: true
-          promtool_actions_version: "2.26.0"
-
   e2e-tests:
     name: E2E tests
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ diff
 !monitoring-satellite/manifests/grafana/*
 !monitoring-satellite/manifests/kubescape/*
 !monitoring-satellite/manifests/probers/*
+!monitoring-satellite/manifests/kube-prometheus-rules/*

--- a/installer/cmd/render.go
+++ b/installer/cmd/render.go
@@ -167,6 +167,9 @@ func renderKubernetesObjects(cfg *config.Config) ([]string, error) {
 		output = append(output, proberImporter.Import()...)
 	}
 
+	kubePrometheusRulesImporter := importer.NewYAMLImporter("https://github.com/gitpod-io/observability", "monitoring-satellite/manifests/kube-prometheus-rules")
+	output = append(output, kubePrometheusRulesImporter.Import()...)
+
 	return output, nil
 }
 

--- a/monitoring-satellite/manifests/kube-prometheus-rules/rules.yaml
+++ b/monitoring-satellite/manifests/kube-prometheus-rules/rules.yaml
@@ -1,0 +1,2254 @@
+prometheusRule:
+  apiVersion: monitoring.coreos.com/v1
+  kind: PrometheusRule
+  metadata:
+    name: kube-prometheus-rules
+    namespace: monitoring-satellite
+  spec:
+    groups:
+    - name: general.rules
+      rules:
+      - alert: TargetDown
+        annotations:
+          description: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{ $labels.service }} targets in {{ $labels.namespace }} namespace are down.'
+          runbook_url: https://runbooks.prometheus-operator.dev/runbooks/general/targetdown
+          summary: One or more targets are unreachable.
+        expr: 100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job, namespace, service)) > 10
+        for: 10m
+        labels:
+          severity: warning
+      - alert: InfoInhibitor
+        annotations:
+          description: |
+            This is an alert that is used to inhibit info alerts.
+            By themselves, the info-level alerts are sometimes very noisy, but they are relevant when combined with
+            other alerts.
+            This alert fires whenever there's a severity="info" alert, and stops firing when another alert with a
+            severity of 'warning' or 'critical' starts firing on the same namespace.
+            This alert should be routed to a null receiver and configured to inhibit alerts with severity="info".
+          runbook_url: https://runbooks.prometheus-operator.dev/runbooks/general/infoinhibitor
+          summary: Info-level alert inhibition.
+        expr: ALERTS{severity = "info"} == 1 unless on(namespace) ALERTS{alertname != "InfoInhibitor", severity =~ "warning|critical", alertstate="firing"} == 1
+        labels:
+          severity: none
+    - name: node-network
+      rules:
+      - alert: NodeNetworkInterfaceFlapping
+        annotations:
+          description: Network interface "{{ $labels.device }}" changing its up status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}
+          runbook_url: https://runbooks.prometheus-operator.dev/runbooks/general/nodenetworkinterfaceflapping
+          summary: Network interface is often changing its status
+        expr: |
+          changes(node_network_up{job="node-exporter",device!~"veth.+"}[2m]) > 2
+        for: 2m
+        labels:
+          severity: warning
+    - name: kube-prometheus-node-recording.rules
+      rules:
+      - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[3m])) BY (instance)
+        record: instance:node_cpu:rate:sum
+      - expr: sum(rate(node_network_receive_bytes_total[3m])) BY (instance)
+        record: instance:node_network_receive_bytes:rate:sum
+      - expr: sum(rate(node_network_transmit_bytes_total[3m])) BY (instance)
+        record: instance:node_network_transmit_bytes:rate:sum
+      - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[5m])) WITHOUT (cpu, mode) / ON(instance) GROUP_LEFT() count(sum(node_cpu_seconds_total) BY (instance, cpu)) BY (instance)
+        record: instance:node_cpu:ratio
+      - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[5m]))
+        record: cluster:node_cpu:sum_rate5m
+      - expr: cluster:node_cpu:sum_rate5m / count(sum(node_cpu_seconds_total) BY (instance, cpu))
+        record: cluster:node_cpu:ratio
+    - name: kube-prometheus-general.rules
+      rules:
+      - expr: count without(instance, pod, node) (up == 1)
+        record: count:up1
+      - expr: count without(instance, pod, node) (up == 0)
+        record: count:up0
+    - name: alertmanager.rules
+      rules:
+      - alert: AlertmanagerFailedReload
+        annotations:
+          description: Configuration has failed to load for {{ $labels.namespace }}/{{ $labels.pod}}.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/AlertmanagerFailedReload.md
+          summary: Reloading an Alertmanager configuration has failed.
+        expr: |
+          # Without max_over_time, failed scrapes could create false negatives, see
+          # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+          max_over_time(alertmanager_config_last_reload_successful{job="alertmanager-main",namespace="monitoring-satellite"}[5m]) == 0
+        for: 10m
+        labels:
+          severity: critical
+      - alert: AlertmanagerMembersInconsistent
+        annotations:
+          description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} has only found {{ $value }} members of the {{$labels.job}} cluster.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/AlertmanagerMembersInconsistent.md
+          summary: A member of an Alertmanager cluster has not found all other cluster members.
+        expr: |
+          # Without max_over_time, failed scrapes could create false negatives, see
+          # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+            max_over_time(alertmanager_cluster_members{job="alertmanager-main",namespace="monitoring-satellite"}[5m])
+          < on (cluster) group_left
+            count by (cluster) (max_over_time(alertmanager_cluster_members{job="alertmanager-main",namespace="monitoring-satellite"}[5m]))
+        for: 15m
+        labels:
+          severity: critical
+      - alert: AlertmanagerFailedToSendAlerts
+        annotations:
+          description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed to send {{ $value | humanizePercentage }} of notifications to {{ $labels.integration }}.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/AlertmanagerFailedToSendAlerts.md
+          summary: An Alertmanager instance failed to send notifications.
+        expr: |
+          (
+            rate(alertmanager_notifications_failed_total{job="alertmanager-main",namespace="monitoring-satellite"}[5m])
+          /
+            rate(alertmanager_notifications_total{job="alertmanager-main",namespace="monitoring-satellite"}[5m])
+          )
+          > 0.01
+        for: 5m
+        labels:
+          severity: warning
+      - alert: AlertmanagerClusterFailedToSendAlerts
+        annotations:
+          description: The minimum notification failure rate to {{ $labels.integration }} sent from any instance in the {{$labels.job}} cluster is {{ $value | humanizePercentage }}.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/AlertmanagerClusterFailedToSendAlerts.md
+          summary: All Alertmanager instances in a cluster failed to send notifications to a critical integration.
+        expr: |
+          min by (cluster, integration) (
+            rate(alertmanager_notifications_failed_total{job="alertmanager-main",namespace="monitoring-satellite", integration=~`slack|pagerduty`}[5m])
+          /
+            rate(alertmanager_notifications_total{job="alertmanager-main",namespace="monitoring-satellite", integration=~`slack|pagerduty`}[5m])
+          )
+          > 0.01
+        for: 5m
+        labels:
+          severity: critical
+      - alert: AlertmanagerClusterFailedToSendAlerts
+        annotations:
+          description: The minimum notification failure rate to {{ $labels.integration }} sent from any instance in the {{$labels.job}} cluster is {{ $value | humanizePercentage }}.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/AlertmanagerClusterFailedToSendAlerts.md
+          summary: All Alertmanager instances in a cluster failed to send notifications to a non-critical integration.
+        expr: |
+          min by (cluster, integration) (
+            rate(alertmanager_notifications_failed_total{job="alertmanager-main",namespace="monitoring-satellite", integration!~`slack|pagerduty`}[5m])
+          /
+            rate(alertmanager_notifications_total{job="alertmanager-main",namespace="monitoring-satellite", integration!~`slack|pagerduty`}[5m])
+          )
+          > 0.01
+        for: 5m
+        labels:
+          severity: warning
+      - alert: AlertmanagerConfigInconsistent
+        annotations:
+          description: Alertmanager instances within the {{$labels.job}} cluster have different configurations.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/AlertmanagerConfigInconsistent.md
+          summary: Alertmanager instances within the same cluster have different configurations.
+        expr: |
+          count by (cluster) (
+            count_values by (cluster) ("config_hash", alertmanager_config_hash{job="alertmanager-main",namespace="monitoring-satellite"})
+          )
+          != 1
+        for: 20m
+        labels:
+          severity: critical
+      - alert: AlertmanagerClusterDown
+        annotations:
+          description: '{{ $value | humanizePercentage }} of Alertmanager instances within the {{$labels.job}} cluster have been up for less than half of the last 5m.'
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/AlertmanagerClusterDown.md
+          summary: Half or more of the Alertmanager instances within the same cluster are down.
+        expr: |
+          (
+            count by (cluster) (
+              avg_over_time(up{job="alertmanager-main",namespace="monitoring-satellite"}[5m]) < 0.5
+            )
+          /
+            count by (cluster) (
+              up{job="alertmanager-main",namespace="monitoring-satellite"}
+            )
+          )
+          >= 0.5
+        for: 5m
+        labels:
+          severity: critical
+      - alert: AlertmanagerClusterCrashlooping
+        annotations:
+          description: '{{ $value | humanizePercentage }} of Alertmanager instances within the {{$labels.job}} cluster have restarted at least 5 times in the last 10m.'
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/AlertmanagerClusterCrashlooping.md
+          summary: Half or more of the Alertmanager instances within the same cluster are crashlooping.
+        expr: |
+          (
+            count by (cluster) (
+              changes(process_start_time_seconds{job="alertmanager-main",namespace="monitoring-satellite"}[10m]) > 4
+            )
+          /
+            count by (cluster) (
+              up{job="alertmanager-main",namespace="monitoring-satellite"}
+            )
+          )
+          >= 0.5
+        for: 5m
+        labels:
+          severity: critical
+    - name: kube-state-metrics
+      rules:
+      - alert: KubeStateMetricsWatchErrors
+        annotations:
+          description: kube-state-metrics is experiencing errors at an elevated rate in watch operations. This is likely causing it to not be able to expose metrics about Kubernetes objects correctly or at all.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeStateMetricsWatchErrors.md
+          summary: kube-state-metrics is experiencing errors in watch operations.
+        expr: |
+          (sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics",result="error"}[5m]))
+            /
+          sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics"}[5m])))
+          > 0.01
+        for: 15m
+        labels:
+          severity: critical
+      - alert: KubeStateMetricsShardingMismatch
+        annotations:
+          description: kube-state-metrics pods are running with different --total-shards configuration, some Kubernetes objects may be exposed multiple times or not exposed at all.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeStateMetricsShardingMismatch.md
+          summary: kube-state-metrics sharding is misconfigured.
+        expr: |
+          stdvar (kube_state_metrics_total_shards{job="kube-state-metrics"}) != 0
+        for: 15m
+        labels:
+          severity: critical
+      - alert: KubeStateMetricsShardsMissing
+        annotations:
+          description: kube-state-metrics shards are missing, some Kubernetes objects are not being exposed.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeStateMetricsShardsMissing.md
+          summary: kube-state-metrics shards are missing.
+        expr: |
+          2^max(kube_state_metrics_total_shards{job="kube-state-metrics"}) - 1
+            -
+          sum( 2 ^ max by (shard_ordinal) (kube_state_metrics_shard_ordinal{job="kube-state-metrics"}) )
+          != 0
+        for: 15m
+        labels:
+          severity: critical
+    - name: kubernetes-apps
+      rules:
+      - alert: KubePodCrashLooping
+        annotations:
+          description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is in waiting state (reason: "CrashLoopBackOff").'
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubePodCrashLooping.md
+          summary: Pod is crash looping.
+        expr: |
+          max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", job="kube-state-metrics"}[5m]) >= 1
+        for: 15m
+        labels:
+          severity: warning
+      - alert: KubeDeploymentGenerationMismatch
+        annotations:
+          description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match, this indicates that the Deployment has failed but has not been rolled back.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeDeploymentGenerationMismatch.md
+          summary: Deployment generation mismatch due to possible roll-back
+        expr: |
+          kube_deployment_status_observed_generation{job="kube-state-metrics"}
+            !=
+          kube_deployment_metadata_generation{job="kube-state-metrics"}
+        for: 15m
+        labels:
+          severity: warning
+      - alert: KubeDeploymentReplicasMismatch
+        annotations:
+          description: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeDeploymentReplicasMismatch.md
+          summary: Deployment has not matched the expected number of replicas.
+        expr: |
+          (
+            kube_deployment_spec_replicas{job="kube-state-metrics"}
+              >
+            kube_deployment_status_replicas_available{job="kube-state-metrics"}
+          ) and (
+            changes(kube_deployment_status_replicas_updated{job="kube-state-metrics"}[10m])
+              ==
+            0
+          )
+        for: 15m
+        labels:
+          severity: warning
+      - alert: KubeStatefulSetReplicasMismatch
+        annotations:
+          description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has not matched the expected number of replicas for longer than 15 minutes.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeStatefulSetReplicasMismatch.md
+          summary: Deployment has not matched the expected number of replicas.
+        expr: |
+          (
+            kube_statefulset_status_replicas_ready{job="kube-state-metrics"}
+              !=
+            kube_statefulset_status_replicas{job="kube-state-metrics"}
+          ) and (
+            changes(kube_statefulset_status_replicas_updated{job="kube-state-metrics"}[10m])
+              ==
+            0
+          )
+        for: 15m
+        labels:
+          severity: warning
+      - alert: KubeStatefulSetGenerationMismatch
+        annotations:
+          description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset }} does not match, this indicates that the StatefulSet has failed but has not been rolled back.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeStatefulSetGenerationMismatch.md
+          summary: StatefulSet generation mismatch due to possible roll-back
+        expr: |
+          kube_statefulset_status_observed_generation{job="kube-state-metrics"}
+            !=
+          kube_statefulset_metadata_generation{job="kube-state-metrics"}
+        for: 15m
+        labels:
+          severity: warning
+      - alert: KubeStatefulSetUpdateNotRolledOut
+        annotations:
+          description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update has not been rolled out.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeStatefulSetUpdateNotRolledOut.md
+          summary: StatefulSet update has not been rolled out.
+        expr: |
+          (
+            max without (revision) (
+              kube_statefulset_status_current_revision{job="kube-state-metrics"}
+                unless
+              kube_statefulset_status_update_revision{job="kube-state-metrics"}
+            )
+              *
+            (
+              kube_statefulset_replicas{job="kube-state-metrics"}
+                !=
+              kube_statefulset_status_replicas_updated{job="kube-state-metrics"}
+            )
+          )  and (
+            changes(kube_statefulset_status_replicas_updated{job="kube-state-metrics"}[5m])
+              ==
+            0
+          )
+        for: 15m
+        labels:
+          severity: warning
+      - alert: KubeDaemonSetRolloutStuck
+        annotations:
+          description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} has not finished or progressed for at least 15 minutes.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeDaemonSetRolloutStuck.md
+          summary: DaemonSet rollout is stuck.
+        expr: |
+          (
+            (
+              kube_daemonset_status_current_number_scheduled{job="kube-state-metrics"}
+               !=
+              kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
+            ) or (
+              kube_daemonset_status_number_misscheduled{job="kube-state-metrics"}
+               !=
+              0
+            ) or (
+              kube_daemonset_status_updated_number_scheduled{job="kube-state-metrics"}
+               !=
+              kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
+            ) or (
+              kube_daemonset_status_number_available{job="kube-state-metrics"}
+               !=
+              kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
+            )
+          ) and (
+            changes(kube_daemonset_status_updated_number_scheduled{job="kube-state-metrics"}[5m])
+              ==
+            0
+          )
+        for: 15m
+        labels:
+          severity: warning
+      - alert: KubeContainerWaiting
+        annotations:
+          description: pod/{{ $labels.pod }} in namespace {{ $labels.namespace }} on container {{ $labels.container}} has been in waiting state for longer than 1 hour.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeContainerWaiting.md
+          summary: Pod container waiting longer than 1 hour
+        expr: |
+          sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{job="kube-state-metrics"}) > 0
+        for: 1h
+        labels:
+          severity: warning
+      - alert: KubeDaemonSetNotScheduled
+        annotations:
+          description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are not scheduled.'
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeDaemonSetNotScheduled.md
+          summary: DaemonSet pods are not scheduled.
+        expr: |
+          kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
+            -
+          kube_daemonset_status_current_number_scheduled{job="kube-state-metrics"} > 0
+        for: 10m
+        labels:
+          severity: warning
+      - alert: KubeDaemonSetMisScheduled
+        annotations:
+          description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are running where they are not supposed to run.'
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeDaemonSetMisScheduled.md
+          summary: DaemonSet pods are misscheduled.
+        expr: |
+          kube_daemonset_status_number_misscheduled{job="kube-state-metrics"} > 0
+        for: 15m
+        labels:
+          severity: warning
+      - alert: KubeJobNotCompleted
+        annotations:
+          description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than {{ "43200" | humanizeDuration }} to complete.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeJobNotCompleted.md
+          summary: Job did not complete in time
+        expr: |
+          time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{job="kube-state-metrics"}
+            and
+          kube_job_status_active{job="kube-state-metrics"} > 0) > 43200
+        labels:
+          severity: warning
+      - alert: KubeJobFailed
+        annotations:
+          description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete. Removing failed job after investigation should clear this alert.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeJobFailed.md
+          summary: Job failed to complete.
+        expr: |
+          kube_job_failed{job="kube-state-metrics"}  > 0
+        for: 15m
+        labels:
+          severity: warning
+      - alert: KubeHpaReplicasMismatch
+        annotations:
+          description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }} has not matched the desired number of replicas for longer than 15 minutes.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeHpaReplicasMismatch.md
+          summary: HPA has not matched descired number of replicas.
+        expr: |
+          (kube_horizontalpodautoscaler_status_desired_replicas{job="kube-state-metrics"}
+            !=
+          kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"})
+            and
+          (kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"}
+            >
+          kube_horizontalpodautoscaler_spec_min_replicas{job="kube-state-metrics"})
+            and
+          (kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"}
+            <
+          kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics"})
+            and
+          changes(kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"}[15m]) == 0
+        for: 15m
+        labels:
+          severity: warning
+      - alert: KubeHpaMaxedOut
+        annotations:
+          description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }} has been running at max replicas for longer than 15 minutes.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeHpaMaxedOut.md
+          summary: HPA is running at max replicas
+        expr: |
+          kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"}
+            ==
+          kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics"}
+        for: 15m
+        labels:
+          severity: warning
+    - name: kubernetes-resources
+      rules:
+      - alert: KubeCPUOvercommit
+        annotations:
+          description: Cluster has overcommitted CPU resource requests for Pods by {{ $value }} CPU shares and cannot tolerate node failure.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeCPUOvercommit.md
+          summary: Cluster has overcommitted CPU resource requests.
+        expr: |
+          sum(namespace_cpu:kube_pod_container_resource_requests:sum{}) - (sum(kube_node_status_allocatable{resource="cpu"}) - max(kube_node_status_allocatable{resource="cpu"})) > 0
+          and
+          (sum(kube_node_status_allocatable{resource="cpu"}) - max(kube_node_status_allocatable{resource="cpu"})) > 0
+        for: 10m
+        labels:
+          severity: warning
+      - alert: KubeMemoryOvercommit
+        annotations:
+          description: Cluster has overcommitted memory resource requests for Pods by {{ $value | humanize }} bytes and cannot tolerate node failure.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeMemoryOvercommit.md
+          summary: Cluster has overcommitted memory resource requests.
+        expr: |
+          sum(namespace_memory:kube_pod_container_resource_requests:sum{}) - (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"})) > 0
+          and
+          (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"})) > 0
+        for: 10m
+        labels:
+          severity: warning
+      - alert: KubeCPUQuotaOvercommit
+        annotations:
+          description: Cluster has overcommitted CPU resource requests for Namespaces.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeCPUQuotaOvercommit.md
+          summary: Cluster has overcommitted CPU resource requests.
+        expr: |
+          sum(min without(resource) (kube_resourcequota{job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
+            /
+          sum(kube_node_status_allocatable{resource="cpu", job="kube-state-metrics"})
+            > 1.5
+        for: 5m
+        labels:
+          severity: warning
+      - alert: KubeMemoryQuotaOvercommit
+        annotations:
+          description: Cluster has overcommitted memory resource requests for Namespaces.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeMemoryQuotaOvercommit.md
+          summary: Cluster has overcommitted memory resource requests.
+        expr: |
+          sum(min without(resource) (kube_resourcequota{job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
+            /
+          sum(kube_node_status_allocatable{resource="memory", job="kube-state-metrics"})
+            > 1.5
+        for: 5m
+        labels:
+          severity: warning
+      - alert: KubeQuotaAlmostFull
+        annotations:
+          description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage }} of its {{ $labels.resource }} quota.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeQuotaAlmostFull.md
+          summary: Namespace quota is going to be full.
+        expr: |
+          kube_resourcequota{job="kube-state-metrics", type="used"}
+            / ignoring(instance, job, type)
+          (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+            > 0.9 < 1
+        for: 15m
+        labels:
+          severity: info
+      - alert: KubeQuotaFullyUsed
+        annotations:
+          description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage }} of its {{ $labels.resource }} quota.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeQuotaFullyUsed.md
+          summary: Namespace quota is fully used.
+        expr: |
+          kube_resourcequota{job="kube-state-metrics", type="used"}
+            / ignoring(instance, job, type)
+          (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+            == 1
+        for: 15m
+        labels:
+          severity: info
+      - alert: KubeQuotaExceeded
+        annotations:
+          description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage }} of its {{ $labels.resource }} quota.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeQuotaExceeded.md
+          summary: Namespace quota has exceeded the limits.
+        expr: |
+          kube_resourcequota{job="kube-state-metrics", type="used"}
+            / ignoring(instance, job, type)
+          (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+            > 1
+        for: 15m
+        labels:
+          severity: warning
+    - name: kubernetes-storage
+      rules:
+      - alert: KubePersistentVolumeFillingUp
+        annotations:
+          description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubePersistentVolumeFillingUp.md
+          summary: PersistentVolume is filling up.
+        expr: |
+          (
+            kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"}
+              /
+            kubelet_volume_stats_capacity_bytes{job="kubelet", metrics_path="/metrics"}
+          ) < 0.03
+          and
+          kubelet_volume_stats_used_bytes{job="kubelet", metrics_path="/metrics"} > 0
+          unless on(namespace, persistentvolumeclaim)
+          kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+          unless on(namespace, persistentvolumeclaim)
+          kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
+        for: 1m
+        labels:
+          severity: critical
+      - alert: KubePersistentVolumeFillingUp
+        annotations:
+          description: Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ $value | humanizePercentage }} is available.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubePersistentVolumeFillingUp.md
+          summary: PersistentVolume is filling up.
+        expr: |
+          (
+            kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"}
+              /
+            kubelet_volume_stats_capacity_bytes{job="kubelet", metrics_path="/metrics"}
+          ) < 0.15
+          and
+          kubelet_volume_stats_used_bytes{job="kubelet", metrics_path="/metrics"} > 0
+          and
+          predict_linear(kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
+          unless on(namespace, persistentvolumeclaim)
+          kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+          unless on(namespace, persistentvolumeclaim)
+          kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
+        for: 1h
+        labels:
+          severity: warning
+      - alert: KubePersistentVolumeInodesFillingUp
+        annotations:
+          description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} only has {{ $value | humanizePercentage }} free inodes.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubePersistentVolumeInodesFillingUp.md
+          summary: PersistentVolumeInodes are filling up.
+        expr: |
+          (
+            kubelet_volume_stats_inodes_free{job="kubelet", metrics_path="/metrics"}
+              /
+            kubelet_volume_stats_inodes{job="kubelet", metrics_path="/metrics"}
+          ) < 0.03
+          and
+          kubelet_volume_stats_inodes_used{job="kubelet", metrics_path="/metrics"} > 0
+          unless on(namespace, persistentvolumeclaim)
+          kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+          unless on(namespace, persistentvolumeclaim)
+          kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
+        for: 1m
+        labels:
+          severity: critical
+      - alert: KubePersistentVolumeInodesFillingUp
+        annotations:
+          description: Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to run out of inodes within four days. Currently {{ $value | humanizePercentage }} of its inodes are free.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubePersistentVolumeInodesFillingUp.md
+          summary: PersistentVolumeInodes are filling up.
+        expr: |
+          (
+            kubelet_volume_stats_inodes_free{job="kubelet", metrics_path="/metrics"}
+              /
+            kubelet_volume_stats_inodes{job="kubelet", metrics_path="/metrics"}
+          ) < 0.15
+          and
+          kubelet_volume_stats_inodes_used{job="kubelet", metrics_path="/metrics"} > 0
+          and
+          predict_linear(kubelet_volume_stats_inodes_free{job="kubelet", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
+          unless on(namespace, persistentvolumeclaim)
+          kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+          unless on(namespace, persistentvolumeclaim)
+          kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
+        for: 1h
+        labels:
+          severity: warning
+      - alert: KubePersistentVolumeErrors
+        annotations:
+          description: The persistent volume {{ $labels.persistentvolume }} has status {{ $labels.phase }}.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubePersistentVolumeErrors.md
+          summary: PersistentVolume is having issues with provisioning.
+        expr: |
+          kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} > 0
+        for: 5m
+        labels:
+          severity: critical
+    - name: kubernetes-system
+      rules:
+      - alert: KubeVersionMismatch
+        annotations:
+          description: There are {{ $value }} different semantic versions of Kubernetes components running.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeVersionMismatch.md
+          summary: Different semantic versions of Kubernetes components running.
+        expr: |
+          count by (cluster) (count by (git_version, cluster) (label_replace(kubernetes_build_info{job!~"kube-dns|coredns"},"git_version","$1","git_version","(v[0-9]*.[0-9]*).*"))) > 1
+        for: 15m
+        labels:
+          severity: warning
+      - alert: KubeClientErrors
+        annotations:
+          description: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ $value | humanizePercentage }} errors.'
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeClientErrors.md
+          summary: Kubernetes API server client is experiencing errors.
+        expr: |
+          (sum(rate(rest_client_requests_total{code=~"5.."}[5m])) by (cluster, instance, job, namespace)
+            /
+          sum(rate(rest_client_requests_total[5m])) by (cluster, instance, job, namespace))
+          > 0.01
+        for: 15m
+        labels:
+          severity: warning
+    - name: kube-apiserver-slos
+      rules:
+      - alert: KubeAPIErrorBudgetBurn
+        annotations:
+          description: The API server is burning too much error budget.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeAPIErrorBudgetBurn.md
+          summary: The API server is burning too much error budget.
+        expr: |
+          sum(apiserver_request:burnrate1h) > (14.40 * 0.01000)
+          and
+          sum(apiserver_request:burnrate5m) > (14.40 * 0.01000)
+        for: 2m
+        labels:
+          long: 1h
+          severity: critical
+          short: 5m
+      - alert: KubeAPIErrorBudgetBurn
+        annotations:
+          description: The API server is burning too much error budget.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeAPIErrorBudgetBurn.md
+          summary: The API server is burning too much error budget.
+        expr: |
+          sum(apiserver_request:burnrate6h) > (6.00 * 0.01000)
+          and
+          sum(apiserver_request:burnrate30m) > (6.00 * 0.01000)
+        for: 15m
+        labels:
+          long: 6h
+          severity: critical
+          short: 30m
+      - alert: KubeAPIErrorBudgetBurn
+        annotations:
+          description: The API server is burning too much error budget.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeAPIErrorBudgetBurn.md
+          summary: The API server is burning too much error budget.
+        expr: |
+          sum(apiserver_request:burnrate1d) > (3.00 * 0.01000)
+          and
+          sum(apiserver_request:burnrate2h) > (3.00 * 0.01000)
+        for: 1h
+        labels:
+          long: 1d
+          severity: warning
+          short: 2h
+      - alert: KubeAPIErrorBudgetBurn
+        annotations:
+          description: The API server is burning too much error budget.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeAPIErrorBudgetBurn.md
+          summary: The API server is burning too much error budget.
+        expr: |
+          sum(apiserver_request:burnrate3d) > (1.00 * 0.01000)
+          and
+          sum(apiserver_request:burnrate6h) > (1.00 * 0.01000)
+        for: 3h
+        labels:
+          long: 3d
+          severity: warning
+          short: 6h
+    - name: kubernetes-system-apiserver
+      rules:
+      - alert: KubeClientCertificateExpiration
+        annotations:
+          description: A client certificate used to authenticate to kubernetes apiserver is expiring in less than 7.0 days.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeClientCertificateExpiration.md
+          summary: Client certificate is about to expire.
+        expr: |
+          apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 604800
+        labels:
+          severity: warning
+      - alert: KubeClientCertificateExpiration
+        annotations:
+          description: A client certificate used to authenticate to kubernetes apiserver is expiring in less than 24.0 hours.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeClientCertificateExpiration.md
+          summary: Client certificate is about to expire.
+        expr: |
+          apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 86400
+        labels:
+          severity: critical
+      - alert: KubeAggregatedAPIErrors
+        annotations:
+          description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace }} has reported errors. It has appeared unavailable {{ $value | humanize }} times averaged over the past 10m.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeAggregatedAPIErrors.md
+          summary: Kubernetes aggregated API has reported errors.
+        expr: |
+          sum by(name, namespace, cluster)(increase(aggregator_unavailable_apiservice_total[10m])) > 4
+        labels:
+          severity: warning
+      - alert: KubeAggregatedAPIDown
+        annotations:
+          description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace }} has been only {{ $value | humanize }}% available over the last 10m.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeAggregatedAPIDown.md
+          summary: Kubernetes aggregated API is down.
+        expr: |
+          (1 - max by(name, namespace, cluster)(avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 85
+        for: 5m
+        labels:
+          severity: warning
+      - alert: KubeAPIDown
+        annotations:
+          description: KubeAPI has disappeared from Prometheus target discovery.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeAPIDown.md
+          summary: Target disappeared from Prometheus target discovery.
+        expr: |
+          absent(up{job="apiserver"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+      - alert: KubeAPITerminatedRequests
+        annotations:
+          description: The kubernetes apiserver has terminated {{ $value | humanizePercentage }} of its incoming requests.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeAPITerminatedRequests.md
+          summary: The kubernetes apiserver has terminated {{ $value | humanizePercentage }} of its incoming requests.
+        expr: |
+          sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m]))  / (  sum(rate(apiserver_request_total{job="apiserver"}[10m])) + sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m])) ) > 0.20
+        for: 5m
+        labels:
+          severity: warning
+    - name: kubernetes-system-kubelet
+      rules:
+      - alert: KubeNodeNotReady
+        annotations:
+          description: '{{ $labels.node }} has been unready for more than 15 minutes.'
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeNodeNotReady.md
+          summary: Node is not ready.
+        expr: |
+          kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
+        for: 15m
+        labels:
+          severity: critical
+      - alert: KubeNodeUnreachable
+        annotations:
+          description: '{{ $labels.node }} is unreachable and some workloads may be rescheduled.'
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeNodeUnreachable.md
+          summary: Node is unreachable.
+        expr: |
+          (kube_node_spec_taint{job="kube-state-metrics",key="node.kubernetes.io/unreachable",effect="NoSchedule"} unless ignoring(key,value) kube_node_spec_taint{job="kube-state-metrics",key=~"ToBeDeletedByClusterAutoscaler|cloud.google.com/impending-node-termination|aws-node-termination-handler/spot-itn"}) == 1
+        for: 15m
+        labels:
+          severity: warning
+      - alert: KubeletTooManyPods
+        annotations:
+          description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage }} of its Pod capacity.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeletTooManyPods.md
+          summary: Kubelet is running at capacity.
+        expr: |
+          count by(cluster, node) (
+            (kube_pod_status_phase{job="kube-state-metrics",phase="Running"} == 1) * on(instance,pod,namespace,cluster) group_left(node) topk by(instance,pod,namespace,cluster) (1, kube_pod_info{job="kube-state-metrics"})
+          )
+          /
+          max by(cluster, node) (
+            kube_node_status_capacity{job="kube-state-metrics",resource="pods"} != 1
+          ) > 0.95
+        for: 15m
+        labels:
+          severity: info
+      - alert: KubeNodeReadinessFlapping
+        annotations:
+          description: The readiness status of node {{ $labels.node }} has changed {{ $value }} times in the last 15 minutes.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeNodeReadinessFlapping.md
+          summary: Node readiness status is flapping.
+        expr: |
+          sum(changes(kube_node_status_condition{status="true",condition="Ready"}[15m])) by (cluster, node) > 2
+        for: 15m
+        labels:
+          severity: warning
+      - alert: KubeletPlegDurationHigh
+        annotations:
+          description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile duration of {{ $value }} seconds on node {{ $labels.node }}.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeletPlegDurationHigh.md
+          summary: Kubelet Pod Lifecycle Event Generator is taking too long to relist.
+        expr: |
+          node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile{quantile="0.99"} >= 10
+        for: 5m
+        labels:
+          severity: warning
+      - alert: KubeletPodStartUpLatencyHigh
+        annotations:
+          description: Kubelet Pod startup 99th percentile latency is {{ $value }} seconds on node {{ $labels.node }}.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeletPodStartUpLatencyHigh.md
+          summary: Kubelet Pod startup latency is too high.
+        expr: |
+          histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{job="kubelet", metrics_path="/metrics"}[5m])) by (cluster, instance, le)) * on(cluster, instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"} > 60
+        for: 15m
+        labels:
+          severity: warning
+      - alert: KubeletClientCertificateExpiration
+        annotations:
+          description: Client certificate for Kubelet on node {{ $labels.node }} expires in {{ $value | humanizeDuration }}.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeletClientCertificateExpiration.md
+          summary: Kubelet client certificate is about to expire.
+        expr: |
+          kubelet_certificate_manager_client_ttl_seconds < 604800
+        labels:
+          severity: warning
+      - alert: KubeletClientCertificateExpiration
+        annotations:
+          description: Client certificate for Kubelet on node {{ $labels.node }} expires in {{ $value | humanizeDuration }}.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeletClientCertificateExpiration.md
+          summary: Kubelet client certificate is about to expire.
+        expr: |
+          kubelet_certificate_manager_client_ttl_seconds < 86400
+        labels:
+          severity: critical
+      - alert: KubeletServerCertificateExpiration
+        annotations:
+          description: Server certificate for Kubelet on node {{ $labels.node }} expires in {{ $value | humanizeDuration }}.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeletServerCertificateExpiration.md
+          summary: Kubelet server certificate is about to expire.
+        expr: |
+          kubelet_certificate_manager_server_ttl_seconds < 604800
+        labels:
+          severity: warning
+      - alert: KubeletServerCertificateExpiration
+        annotations:
+          description: Server certificate for Kubelet on node {{ $labels.node }} expires in {{ $value | humanizeDuration }}.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeletServerCertificateExpiration.md
+          summary: Kubelet server certificate is about to expire.
+        expr: |
+          kubelet_certificate_manager_server_ttl_seconds < 86400
+        labels:
+          severity: critical
+      - alert: KubeletClientCertificateRenewalErrors
+        annotations:
+          description: Kubelet on node {{ $labels.node }} has failed to renew its client certificate ({{ $value | humanize }} errors in the last 5 minutes).
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeletClientCertificateRenewalErrors.md
+          summary: Kubelet has failed to renew its client certificate.
+        expr: |
+          increase(kubelet_certificate_manager_client_expiration_renew_errors[5m]) > 0
+        for: 15m
+        labels:
+          severity: warning
+      - alert: KubeletServerCertificateRenewalErrors
+        annotations:
+          description: Kubelet on node {{ $labels.node }} has failed to renew its server certificate ({{ $value | humanize }} errors in the last 5 minutes).
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeletServerCertificateRenewalErrors.md
+          summary: Kubelet has failed to renew its server certificate.
+        expr: |
+          increase(kubelet_server_expiration_renew_errors[5m]) > 0
+        for: 15m
+        labels:
+          severity: warning
+      - alert: KubeletDown
+        annotations:
+          description: Kubelet has disappeared from Prometheus target discovery.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeletDown.md
+          summary: Target disappeared from Prometheus target discovery.
+        expr: |
+          absent(up{job="kubelet", metrics_path="/metrics"} == 1)
+        for: 15m
+        labels:
+          severity: critical
+    - name: kube-apiserver-burnrate.rules
+      rules:
+      - expr: |
+          (
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_count{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward"}[1d]))
+              -
+              (
+                (
+                  sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope=~"resource|",le="1"}[1d]))
+                  or
+                  vector(0)
+                )
+                +
+                sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope="namespace",le="5"}[1d]))
+                +
+                sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope="cluster",le="30"}[1d]))
+              )
+            )
+            +
+            # errors
+            sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET",code=~"5.."}[1d]))
+          )
+          /
+          sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[1d]))
+        labels:
+          verb: read
+        record: apiserver_request:burnrate1d
+      - expr: |
+          (
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_count{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward"}[1h]))
+              -
+              (
+                (
+                  sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope=~"resource|",le="1"}[1h]))
+                  or
+                  vector(0)
+                )
+                +
+                sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope="namespace",le="5"}[1h]))
+                +
+                sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope="cluster",le="30"}[1h]))
+              )
+            )
+            +
+            # errors
+            sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET",code=~"5.."}[1h]))
+          )
+          /
+          sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[1h]))
+        labels:
+          verb: read
+        record: apiserver_request:burnrate1h
+      - expr: |
+          (
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_count{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward"}[2h]))
+              -
+              (
+                (
+                  sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope=~"resource|",le="1"}[2h]))
+                  or
+                  vector(0)
+                )
+                +
+                sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope="namespace",le="5"}[2h]))
+                +
+                sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope="cluster",le="30"}[2h]))
+              )
+            )
+            +
+            # errors
+            sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET",code=~"5.."}[2h]))
+          )
+          /
+          sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[2h]))
+        labels:
+          verb: read
+        record: apiserver_request:burnrate2h
+      - expr: |
+          (
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_count{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward"}[30m]))
+              -
+              (
+                (
+                  sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope=~"resource|",le="1"}[30m]))
+                  or
+                  vector(0)
+                )
+                +
+                sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope="namespace",le="5"}[30m]))
+                +
+                sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope="cluster",le="30"}[30m]))
+              )
+            )
+            +
+            # errors
+            sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET",code=~"5.."}[30m]))
+          )
+          /
+          sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[30m]))
+        labels:
+          verb: read
+        record: apiserver_request:burnrate30m
+      - expr: |
+          (
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_count{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward"}[3d]))
+              -
+              (
+                (
+                  sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope=~"resource|",le="1"}[3d]))
+                  or
+                  vector(0)
+                )
+                +
+                sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope="namespace",le="5"}[3d]))
+                +
+                sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope="cluster",le="30"}[3d]))
+              )
+            )
+            +
+            # errors
+            sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET",code=~"5.."}[3d]))
+          )
+          /
+          sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[3d]))
+        labels:
+          verb: read
+        record: apiserver_request:burnrate3d
+      - expr: |
+          (
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_count{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward"}[5m]))
+              -
+              (
+                (
+                  sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope=~"resource|",le="1"}[5m]))
+                  or
+                  vector(0)
+                )
+                +
+                sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope="namespace",le="5"}[5m]))
+                +
+                sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope="cluster",le="30"}[5m]))
+              )
+            )
+            +
+            # errors
+            sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET",code=~"5.."}[5m]))
+          )
+          /
+          sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[5m]))
+        labels:
+          verb: read
+        record: apiserver_request:burnrate5m
+      - expr: |
+          (
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_count{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward"}[6h]))
+              -
+              (
+                (
+                  sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope=~"resource|",le="1"}[6h]))
+                  or
+                  vector(0)
+                )
+                +
+                sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope="namespace",le="5"}[6h]))
+                +
+                sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward",scope="cluster",le="30"}[6h]))
+              )
+            )
+            +
+            # errors
+            sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET",code=~"5.."}[6h]))
+          )
+          /
+          sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[6h]))
+        labels:
+          verb: read
+        record: apiserver_request:burnrate6h
+      - expr: |
+          (
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_count{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",subresource!~"proxy|attach|log|exec|portforward"}[1d]))
+              -
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",subresource!~"proxy|attach|log|exec|portforward",le="1"}[1d]))
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[1d]))
+          )
+          /
+          sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1d]))
+        labels:
+          verb: write
+        record: apiserver_request:burnrate1d
+      - expr: |
+          (
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_count{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",subresource!~"proxy|attach|log|exec|portforward"}[1h]))
+              -
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",subresource!~"proxy|attach|log|exec|portforward",le="1"}[1h]))
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[1h]))
+          )
+          /
+          sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1h]))
+        labels:
+          verb: write
+        record: apiserver_request:burnrate1h
+      - expr: |
+          (
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_count{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",subresource!~"proxy|attach|log|exec|portforward"}[2h]))
+              -
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",subresource!~"proxy|attach|log|exec|portforward",le="1"}[2h]))
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[2h]))
+          )
+          /
+          sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[2h]))
+        labels:
+          verb: write
+        record: apiserver_request:burnrate2h
+      - expr: |
+          (
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_count{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",subresource!~"proxy|attach|log|exec|portforward"}[30m]))
+              -
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",subresource!~"proxy|attach|log|exec|portforward",le="1"}[30m]))
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[30m]))
+          )
+          /
+          sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[30m]))
+        labels:
+          verb: write
+        record: apiserver_request:burnrate30m
+      - expr: |
+          (
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_count{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",subresource!~"proxy|attach|log|exec|portforward"}[3d]))
+              -
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",subresource!~"proxy|attach|log|exec|portforward",le="1"}[3d]))
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[3d]))
+          )
+          /
+          sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[3d]))
+        labels:
+          verb: write
+        record: apiserver_request:burnrate3d
+      - expr: |
+          (
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_count{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",subresource!~"proxy|attach|log|exec|portforward"}[5m]))
+              -
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",subresource!~"proxy|attach|log|exec|portforward",le="1"}[5m]))
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[5m]))
+          )
+          /
+          sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
+        labels:
+          verb: write
+        record: apiserver_request:burnrate5m
+      - expr: |
+          (
+            (
+              # too slow
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_count{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",subresource!~"proxy|attach|log|exec|portforward"}[6h]))
+              -
+              sum by (cluster) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",subresource!~"proxy|attach|log|exec|portforward",le="1"}[6h]))
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[6h]))
+          )
+          /
+          sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[6h]))
+        labels:
+          verb: write
+        record: apiserver_request:burnrate6h
+    - name: kube-apiserver-histogram.rules
+      rules:
+      - expr: |
+          histogram_quantile(0.99, sum by (cluster, le, resource) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET",subresource!~"proxy|attach|log|exec|portforward"}[5m]))) > 0
+        labels:
+          quantile: "0.99"
+          verb: read
+        record: cluster_quantile:apiserver_request_slo_duration_seconds:histogram_quantile
+      - expr: |
+          histogram_quantile(0.99, sum by (cluster, le, resource) (rate(apiserver_request_slo_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",subresource!~"proxy|attach|log|exec|portforward"}[5m]))) > 0
+        labels:
+          quantile: "0.99"
+          verb: write
+        record: cluster_quantile:apiserver_request_slo_duration_seconds:histogram_quantile
+    - interval: 3m
+      name: kube-apiserver-availability.rules
+      rules:
+      - expr: |
+          avg_over_time(code_verb:apiserver_request_total:increase1h[30d]) * 24 * 30
+        record: code_verb:apiserver_request_total:increase30d
+      - expr: |
+          sum by (cluster, code) (code_verb:apiserver_request_total:increase30d{verb=~"LIST|GET"})
+        labels:
+          verb: read
+        record: code:apiserver_request_total:increase30d
+      - expr: |
+          sum by (cluster, code) (code_verb:apiserver_request_total:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
+        labels:
+          verb: write
+        record: code:apiserver_request_total:increase30d
+      - expr: |
+          sum by (cluster, verb, scope) (increase(apiserver_request_slo_duration_seconds_count[1h]))
+        record: cluster_verb_scope:apiserver_request_slo_duration_seconds_count:increase1h
+      - expr: |
+          sum by (cluster, verb, scope) (avg_over_time(cluster_verb_scope:apiserver_request_slo_duration_seconds_count:increase1h[30d]) * 24 * 30)
+        record: cluster_verb_scope:apiserver_request_slo_duration_seconds_count:increase30d
+      - expr: |
+          sum by (cluster, verb, scope, le) (increase(apiserver_request_slo_duration_seconds_bucket[1h]))
+        record: cluster_verb_scope_le:apiserver_request_slo_duration_seconds_bucket:increase1h
+      - expr: |
+          sum by (cluster, verb, scope, le) (avg_over_time(cluster_verb_scope_le:apiserver_request_slo_duration_seconds_bucket:increase1h[30d]) * 24 * 30)
+        record: cluster_verb_scope_le:apiserver_request_slo_duration_seconds_bucket:increase30d
+      - expr: |
+          1 - (
+            (
+              # write too slow
+              sum by (cluster) (cluster_verb_scope:apiserver_request_slo_duration_seconds_count:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
+              -
+              sum by (cluster) (cluster_verb_scope_le:apiserver_request_slo_duration_seconds_bucket:increase30d{verb=~"POST|PUT|PATCH|DELETE",le="1"})
+            ) +
+            (
+              # read too slow
+              sum by (cluster) (cluster_verb_scope:apiserver_request_slo_duration_seconds_count:increase30d{verb=~"LIST|GET"})
+              -
+              (
+                (
+                  sum by (cluster) (cluster_verb_scope_le:apiserver_request_slo_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope=~"resource|",le="1"})
+                  or
+                  vector(0)
+                )
+                +
+                sum by (cluster) (cluster_verb_scope_le:apiserver_request_slo_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope="namespace",le="5"})
+                +
+                sum by (cluster) (cluster_verb_scope_le:apiserver_request_slo_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope="cluster",le="30"})
+              )
+            ) +
+            # errors
+            sum by (cluster) (code:apiserver_request_total:increase30d{code=~"5.."} or vector(0))
+          )
+          /
+          sum by (cluster) (code:apiserver_request_total:increase30d)
+        labels:
+          verb: all
+        record: apiserver_request:availability30d
+      - expr: |
+          1 - (
+            sum by (cluster) (cluster_verb_scope:apiserver_request_slo_duration_seconds_count:increase30d{verb=~"LIST|GET"})
+            -
+            (
+              # too slow
+              (
+                sum by (cluster) (cluster_verb_scope_le:apiserver_request_slo_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope=~"resource|",le="1"})
+                or
+                vector(0)
+              )
+              +
+              sum by (cluster) (cluster_verb_scope_le:apiserver_request_slo_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope="namespace",le="5"})
+              +
+              sum by (cluster) (cluster_verb_scope_le:apiserver_request_slo_duration_seconds_bucket:increase30d{verb=~"LIST|GET",scope="cluster",le="30"})
+            )
+            +
+            # errors
+            sum by (cluster) (code:apiserver_request_total:increase30d{verb="read",code=~"5.."} or vector(0))
+          )
+          /
+          sum by (cluster) (code:apiserver_request_total:increase30d{verb="read"})
+        labels:
+          verb: read
+        record: apiserver_request:availability30d
+      - expr: |
+          1 - (
+            (
+              # too slow
+              sum by (cluster) (cluster_verb_scope:apiserver_request_slo_duration_seconds_count:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
+              -
+              sum by (cluster) (cluster_verb_scope_le:apiserver_request_slo_duration_seconds_bucket:increase30d{verb=~"POST|PUT|PATCH|DELETE",le="1"})
+            )
+            +
+            # errors
+            sum by (cluster) (code:apiserver_request_total:increase30d{verb="write",code=~"5.."} or vector(0))
+          )
+          /
+          sum by (cluster) (code:apiserver_request_total:increase30d{verb="write"})
+        labels:
+          verb: write
+        record: apiserver_request:availability30d
+      - expr: |
+          sum by (cluster,code,resource) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[5m]))
+        labels:
+          verb: read
+        record: code_resource:apiserver_request_total:rate5m
+      - expr: |
+          sum by (cluster,code,resource) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
+        labels:
+          verb: write
+        record: code_resource:apiserver_request_total:rate5m
+      - expr: |
+          sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"2.."}[1h]))
+        record: code_verb:apiserver_request_total:increase1h
+      - expr: |
+          sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"3.."}[1h]))
+        record: code_verb:apiserver_request_total:increase1h
+      - expr: |
+          sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"4.."}[1h]))
+        record: code_verb:apiserver_request_total:increase1h
+      - expr: |
+          sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"5.."}[1h]))
+        record: code_verb:apiserver_request_total:increase1h
+    - name: k8s.rules
+      rules:
+      - expr: |
+          sum by (cluster, namespace, pod, container) (
+            irate(container_cpu_usage_seconds_total{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}[5m])
+          ) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (
+            1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
+          )
+        record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
+      - expr: |
+          container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+          * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
+            max by(namespace, pod, node) (kube_pod_info{node!=""})
+          )
+        record: node_namespace_pod_container:container_memory_working_set_bytes
+      - expr: |
+          container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+          * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
+            max by(namespace, pod, node) (kube_pod_info{node!=""})
+          )
+        record: node_namespace_pod_container:container_memory_rss
+      - expr: |
+          container_memory_cache{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+          * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
+            max by(namespace, pod, node) (kube_pod_info{node!=""})
+          )
+        record: node_namespace_pod_container:container_memory_cache
+      - expr: |
+          container_memory_swap{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+          * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
+            max by(namespace, pod, node) (kube_pod_info{node!=""})
+          )
+        record: node_namespace_pod_container:container_memory_swap
+      - expr: |
+          kube_pod_container_resource_requests{resource="memory",job="kube-state-metrics"}  * on (namespace, pod, cluster)
+          group_left() max by (namespace, pod, cluster) (
+            (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
+          )
+        record: cluster:namespace:pod_memory:active:kube_pod_container_resource_requests
+      - expr: |
+          sum by (namespace, cluster) (
+              sum by (namespace, pod, cluster) (
+                  max by (namespace, pod, container, cluster) (
+                    kube_pod_container_resource_requests{resource="memory",job="kube-state-metrics"}
+                  ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (
+                    kube_pod_status_phase{phase=~"Pending|Running"} == 1
+                  )
+              )
+          )
+        record: namespace_memory:kube_pod_container_resource_requests:sum
+      - expr: |
+          kube_pod_container_resource_requests{resource="cpu",job="kube-state-metrics"}  * on (namespace, pod, cluster)
+          group_left() max by (namespace, pod, cluster) (
+            (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
+          )
+        record: cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests
+      - expr: |
+          sum by (namespace, cluster) (
+              sum by (namespace, pod, cluster) (
+                  max by (namespace, pod, container, cluster) (
+                    kube_pod_container_resource_requests{resource="cpu",job="kube-state-metrics"}
+                  ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (
+                    kube_pod_status_phase{phase=~"Pending|Running"} == 1
+                  )
+              )
+          )
+        record: namespace_cpu:kube_pod_container_resource_requests:sum
+      - expr: |
+          kube_pod_container_resource_limits{resource="memory",job="kube-state-metrics"}  * on (namespace, pod, cluster)
+          group_left() max by (namespace, pod, cluster) (
+            (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
+          )
+        record: cluster:namespace:pod_memory:active:kube_pod_container_resource_limits
+      - expr: |
+          sum by (namespace, cluster) (
+              sum by (namespace, pod, cluster) (
+                  max by (namespace, pod, container, cluster) (
+                    kube_pod_container_resource_limits{resource="memory",job="kube-state-metrics"}
+                  ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (
+                    kube_pod_status_phase{phase=~"Pending|Running"} == 1
+                  )
+              )
+          )
+        record: namespace_memory:kube_pod_container_resource_limits:sum
+      - expr: |
+          kube_pod_container_resource_limits{resource="cpu",job="kube-state-metrics"}  * on (namespace, pod, cluster)
+          group_left() max by (namespace, pod, cluster) (
+           (kube_pod_status_phase{phase=~"Pending|Running"} == 1)
+           )
+        record: cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits
+      - expr: |
+          sum by (namespace, cluster) (
+              sum by (namespace, pod, cluster) (
+                  max by (namespace, pod, container, cluster) (
+                    kube_pod_container_resource_limits{resource="cpu",job="kube-state-metrics"}
+                  ) * on(namespace, pod, cluster) group_left() max by (namespace, pod, cluster) (
+                    kube_pod_status_phase{phase=~"Pending|Running"} == 1
+                  )
+              )
+          )
+        record: namespace_cpu:kube_pod_container_resource_limits:sum
+      - expr: |
+          max by (cluster, namespace, workload, pod) (
+            label_replace(
+              label_replace(
+                kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet"},
+                "replicaset", "$1", "owner_name", "(.*)"
+              ) * on(replicaset, namespace) group_left(owner_name) topk by(replicaset, namespace) (
+                1, max by (replicaset, namespace, owner_name) (
+                  kube_replicaset_owner{job="kube-state-metrics"}
+                )
+              ),
+              "workload", "$1", "owner_name", "(.*)"
+            )
+          )
+        labels:
+          workload_type: deployment
+        record: namespace_workload_pod:kube_pod_owner:relabel
+      - expr: |
+          max by (cluster, namespace, workload, pod) (
+            label_replace(
+              kube_pod_owner{job="kube-state-metrics", owner_kind="DaemonSet"},
+              "workload", "$1", "owner_name", "(.*)"
+            )
+          )
+        labels:
+          workload_type: daemonset
+        record: namespace_workload_pod:kube_pod_owner:relabel
+      - expr: |
+          max by (cluster, namespace, workload, pod) (
+            label_replace(
+              kube_pod_owner{job="kube-state-metrics", owner_kind="StatefulSet"},
+              "workload", "$1", "owner_name", "(.*)"
+            )
+          )
+        labels:
+          workload_type: statefulset
+        record: namespace_workload_pod:kube_pod_owner:relabel
+      - expr: |
+          max by (cluster, namespace, workload, pod) (
+            label_replace(
+              kube_pod_owner{job="kube-state-metrics", owner_kind="Job"},
+              "workload", "$1", "owner_name", "(.*)"
+            )
+          )
+        labels:
+          workload_type: job
+        record: namespace_workload_pod:kube_pod_owner:relabel
+    - name: kube-scheduler.rules
+      rules:
+      - expr: |
+          histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+        labels:
+          quantile: "0.99"
+        record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+      - expr: |
+          histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+        labels:
+          quantile: "0.99"
+        record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+      - expr: |
+          histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+        labels:
+          quantile: "0.99"
+        record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+      - expr: |
+          histogram_quantile(0.9, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+        labels:
+          quantile: "0.9"
+        record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+      - expr: |
+          histogram_quantile(0.9, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+        labels:
+          quantile: "0.9"
+        record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+      - expr: |
+          histogram_quantile(0.9, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+        labels:
+          quantile: "0.9"
+        record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+      - expr: |
+          histogram_quantile(0.5, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+        labels:
+          quantile: "0.5"
+        record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+      - expr: |
+          histogram_quantile(0.5, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+        labels:
+          quantile: "0.5"
+        record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+      - expr: |
+          histogram_quantile(0.5, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+        labels:
+          quantile: "0.5"
+        record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+    - name: node.rules
+      rules:
+      - expr: |
+          topk by(cluster, namespace, pod) (1,
+            max by (cluster, node, namespace, pod) (
+              label_replace(kube_pod_info{job="kube-state-metrics",node!=""}, "pod", "$1", "pod", "(.*)")
+          ))
+        record: 'node_namespace_pod:kube_pod_info:'
+      - expr: |
+          count by (cluster, node) (sum by (node, cpu) (
+            node_cpu_seconds_total{job="node-exporter"}
+          * on (namespace, pod) group_left(node)
+            topk by(namespace, pod) (1, node_namespace_pod:kube_pod_info:)
+          ))
+        record: node:node_num_cpu:sum
+      - expr: |
+          sum(
+            node_memory_MemAvailable_bytes{job="node-exporter"} or
+            (
+              node_memory_Buffers_bytes{job="node-exporter"} +
+              node_memory_Cached_bytes{job="node-exporter"} +
+              node_memory_MemFree_bytes{job="node-exporter"} +
+              node_memory_Slab_bytes{job="node-exporter"}
+            )
+          ) by (cluster)
+        record: :node_memory_MemAvailable_bytes:sum
+      - expr: |
+          sum(rate(node_cpu_seconds_total{job="node-exporter",mode!="idle",mode!="iowait",mode!="steal"}[5m])) /
+          count(sum(node_cpu_seconds_total{job="node-exporter"}) by (cluster, instance, cpu))
+        record: cluster:node_cpu:ratio_rate5m
+    - name: kubelet.rules
+      rules:
+      - expr: |
+          histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by (cluster, instance, le) * on(cluster, instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"})
+        labels:
+          quantile: "0.99"
+        record: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile
+      - expr: |
+          histogram_quantile(0.9, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by (cluster, instance, le) * on(cluster, instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"})
+        labels:
+          quantile: "0.9"
+        record: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile
+      - expr: |
+          histogram_quantile(0.5, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by (cluster, instance, le) * on(cluster, instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"})
+        labels:
+          quantile: "0.5"
+        record: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile
+    - name: node-exporter
+      rules:
+      - alert: NodeFilesystemAlmostOutOfSpace
+        annotations:
+          description: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available space left.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodeFilesystemAlmostOutOfSpace.md
+          summary: Filesystem has less than 5% space left.
+        expr: |
+          (
+            node_filesystem_avail_bytes{job="node-exporter",fstype!="shiftfs"} / node_filesystem_size_bytes{job="node-exporter",fstype!="shiftfs"} * 100 < 5
+          and
+            node_filesystem_readonly{job="node-exporter",fstype!="shiftfs"} == 0
+          )
+        for: 15m
+        labels:
+          severity: critical
+      - alert: NodeFilesystemAlmostOutOfSpace
+        annotations:
+          description: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available space left.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodeFilesystemAlmostOutOfSpace.md
+          summary: Filesystem has less than 3% space left.
+        expr: |
+          (
+            node_filesystem_avail_bytes{job="node-exporter",fstype!="shiftfs"} / node_filesystem_size_bytes{job="node-exporter",fstype!="shiftfs"} * 100 < 3
+          and
+            node_filesystem_readonly{job="node-exporter",fstype!="shiftfs"} == 0
+          )
+        for: 15m
+        labels:
+          severity: critical
+      - alert: NodeFilesystemFilesFillingUp
+        annotations:
+          description: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left and is filling up.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodeFilesystemFilesFillingUp.md
+          summary: Filesystem is predicted to run out of inodes within the next 24 hours.
+        expr: |
+          (
+            node_filesystem_files_free{job="node-exporter",fstype!="shiftfs"} / node_filesystem_files{job="node-exporter",fstype!="shiftfs"} * 100 < 40
+          and
+            predict_linear(node_filesystem_files_free{job="node-exporter",fstype!="shiftfs"}[6h], 24*60*60) < 0
+          and
+            node_filesystem_readonly{job="node-exporter",fstype!="shiftfs"} == 0
+          )
+        for: 1h
+        labels:
+          severity: warning
+      - alert: NodeFilesystemFilesFillingUp
+        annotations:
+          description: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left and is filling up fast.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodeFilesystemFilesFillingUp.md
+          summary: Filesystem is predicted to run out of inodes within the next 4 hours.
+        expr: |
+          (
+            node_filesystem_files_free{job="node-exporter",fstype!="shiftfs"} / node_filesystem_files{job="node-exporter",fstype!="shiftfs"} * 100 < 20
+          and
+            predict_linear(node_filesystem_files_free{job="node-exporter",fstype!="shiftfs"}[6h], 4*60*60) < 0
+          and
+            node_filesystem_readonly{job="node-exporter",fstype!="shiftfs"} == 0
+          )
+        for: 1h
+        labels:
+          severity: critical
+      - alert: NodeFilesystemAlmostOutOfFiles
+        annotations:
+          description: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodeFilesystemAlmostOutOfFiles.md
+          summary: Filesystem has less than 5% inodes left.
+        expr: |
+          (
+            node_filesystem_files_free{job="node-exporter",fstype!="shiftfs"} / node_filesystem_files{job="node-exporter",fstype!="shiftfs"} * 100 < 5
+          and
+            node_filesystem_readonly{job="node-exporter",fstype!="shiftfs"} == 0
+          )
+        for: 1h
+        labels:
+          severity: warning
+      - alert: NodeFilesystemAlmostOutOfFiles
+        annotations:
+          description: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodeFilesystemAlmostOutOfFiles.md
+          summary: Filesystem has less than 3% inodes left.
+        expr: |
+          (
+            node_filesystem_files_free{job="node-exporter",fstype!="shiftfs"} / node_filesystem_files{job="node-exporter",fstype!="shiftfs"} * 100 < 3
+          and
+            node_filesystem_readonly{job="node-exporter",fstype!="shiftfs"} == 0
+          )
+        for: 1h
+        labels:
+          severity: critical
+      - alert: NodeNetworkReceiveErrs
+        annotations:
+          description: '{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} receive errors in the last two minutes.'
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodeNetworkReceiveErrs.md
+          summary: Network interface is reporting many receive errors.
+        expr: |
+          rate(node_network_receive_errs_total[2m]) / rate(node_network_receive_packets_total[2m]) > 0.01
+        for: 1h
+        labels:
+          severity: warning
+      - alert: NodeNetworkTransmitErrs
+        annotations:
+          description: '{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} transmit errors in the last two minutes.'
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodeNetworkTransmitErrs.md
+          summary: Network interface is reporting many transmit errors.
+        expr: |
+          rate(node_network_transmit_errs_total[2m]) / rate(node_network_transmit_packets_total[2m]) > 0.01
+        for: 1h
+        labels:
+          severity: warning
+      - alert: NodeTextFileCollectorScrapeError
+        annotations:
+          description: Node Exporter text file collector failed to scrape.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodeTextFileCollectorScrapeError.md
+          summary: Node Exporter text file collector failed to scrape.
+        expr: |
+          node_textfile_scrape_error{job="node-exporter"} == 1
+        labels:
+          severity: warning
+      - alert: NodeClockSkewDetected
+        annotations:
+          description: Clock on {{ $labels.instance }} is out of sync by more than 300s. Ensure NTP is configured correctly on this host.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodeClockSkewDetected.md
+          summary: Clock skew detected.
+        expr: |
+          (
+            node_timex_offset_seconds{job="node-exporter"} > 0.05
+          and
+            deriv(node_timex_offset_seconds{job="node-exporter"}[5m]) >= 0
+          )
+          or
+          (
+            node_timex_offset_seconds{job="node-exporter"} < -0.05
+          and
+            deriv(node_timex_offset_seconds{job="node-exporter"}[5m]) <= 0
+          )
+        for: 10m
+        labels:
+          severity: warning
+      - alert: NodeClockNotSynchronising
+        annotations:
+          description: Clock on {{ $labels.instance }} is not synchronising. Ensure NTP is configured on this host.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodeClockNotSynchronising.md
+          summary: Clock not synchronising.
+        expr: |
+          min_over_time(node_timex_sync_status{job="node-exporter"}[5m]) == 0
+          and
+          node_timex_maxerror_seconds{job="node-exporter"} >= 16
+        for: 10m
+        labels:
+          severity: warning
+      - alert: NodeRAIDDegraded
+        annotations:
+          description: RAID array '{{ $labels.device }}' on {{ $labels.instance }} is in degraded state due to one or more disks failures. Number of spare drives is insufficient to fix issue automatically.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodeRAIDDegraded.md
+          summary: RAID Array is degraded
+        expr: |
+          node_md_disks_required{job="node-exporter",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+)"} - ignoring (state) (node_md_disks{state="active",job="node-exporter",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+)"}) > 0
+        for: 15m
+        labels:
+          severity: critical
+      - alert: NodeRAIDDiskFailure
+        annotations:
+          description: At least one device in RAID array on {{ $labels.instance }} failed. Array '{{ $labels.device }}' needs attention and possibly a disk swap.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodeRAIDDiskFailure.md
+          summary: Failed device in RAID array
+        expr: |
+          node_md_disks{state="failed",job="node-exporter",device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+)"} > 0
+        labels:
+          severity: warning
+      - alert: NodeFileDescriptorLimit
+        annotations:
+          description: File descriptors limit at {{ $labels.instance }} is currently at {{ printf "%.2f" $value }}%.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodeFileDescriptorLimit.md
+          summary: Kernel is predicted to exhaust file descriptors limit soon.
+        expr: |
+          (
+            node_filefd_allocated{job="node-exporter"} * 100 / node_filefd_maximum{job="node-exporter"} > 70
+          )
+        for: 15m
+        labels:
+          severity: warning
+      - alert: NodeFileDescriptorLimit
+        annotations:
+          description: File descriptors limit at {{ $labels.instance }} is currently at {{ printf "%.2f" $value }}%.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NodeFileDescriptorLimit.md
+          summary: Kernel is predicted to exhaust file descriptors limit soon.
+        expr: |
+          (
+            node_filefd_allocated{job="node-exporter"} * 100 / node_filefd_maximum{job="node-exporter"} > 90
+          )
+        for: 15m
+        labels:
+          severity: critical
+    - name: node-exporter.rules
+      rules:
+      - expr: |
+          count without (cpu, mode) (
+            node_cpu_seconds_total{job="node-exporter",mode="idle"}
+          )
+        record: instance:node_num_cpu:sum
+      - expr: |
+          1 - avg without (cpu) (
+            sum without (mode) (rate(node_cpu_seconds_total{job="node-exporter", mode=~"idle|iowait|steal"}[5m]))
+          )
+        record: instance:node_cpu_utilisation:rate5m
+      - expr: |
+          (
+            node_load1{job="node-exporter"}
+          /
+            instance:node_num_cpu:sum{job="node-exporter"}
+          )
+        record: instance:node_load1_per_cpu:ratio
+      - expr: |
+          1 - (
+            (
+              node_memory_MemAvailable_bytes{job="node-exporter"}
+              or
+              (
+                node_memory_Buffers_bytes{job="node-exporter"}
+                +
+                node_memory_Cached_bytes{job="node-exporter"}
+                +
+                node_memory_MemFree_bytes{job="node-exporter"}
+                +
+                node_memory_Slab_bytes{job="node-exporter"}
+              )
+            )
+          /
+            node_memory_MemTotal_bytes{job="node-exporter"}
+          )
+        record: instance:node_memory_utilisation:ratio
+      - expr: |
+          rate(node_vmstat_pgmajfault{job="node-exporter"}[5m])
+        record: instance:node_vmstat_pgmajfault:rate5m
+      - expr: |
+          rate(node_disk_io_time_seconds_total{job="node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+)"}[5m])
+        record: instance_device:node_disk_io_time_seconds:rate5m
+      - expr: |
+          rate(node_disk_io_time_weighted_seconds_total{job="node-exporter", device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+)"}[5m])
+        record: instance_device:node_disk_io_time_weighted_seconds:rate5m
+      - expr: |
+          sum without (device) (
+            rate(node_network_receive_bytes_total{job="node-exporter", device!="lo"}[5m])
+          )
+        record: instance:node_network_receive_bytes_excluding_lo:rate5m
+      - expr: |
+          sum without (device) (
+            rate(node_network_transmit_bytes_total{job="node-exporter", device!="lo"}[5m])
+          )
+        record: instance:node_network_transmit_bytes_excluding_lo:rate5m
+      - expr: |
+          sum without (device) (
+            rate(node_network_receive_drop_total{job="node-exporter", device!="lo"}[5m])
+          )
+        record: instance:node_network_receive_drop_excluding_lo:rate5m
+      - expr: |
+          sum without (device) (
+            rate(node_network_transmit_drop_total{job="node-exporter", device!="lo"}[5m])
+          )
+        record: instance:node_network_transmit_drop_excluding_lo:rate5m
+    - name: prometheus
+      rules:
+      - alert: PrometheusBadConfig
+        annotations:
+          description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed to reload its configuration.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusBadConfig.md
+          summary: Failed Prometheus configuration reload.
+        expr: |
+          # Without max_over_time, failed scrapes could create false negatives, see
+          # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+          max_over_time(prometheus_config_last_reload_successful{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]) == 0
+        for: 10m
+        labels:
+          severity: critical
+      - alert: PrometheusNotificationQueueRunningFull
+        annotations:
+          description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}} is running full.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusNotificationQueueRunningFull.md
+          summary: Prometheus alert notification queue predicted to run full in less than 30m.
+        expr: |
+          # Without min_over_time, failed scrapes could create false negatives, see
+          # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+          (
+            predict_linear(prometheus_notifications_queue_length{job="prometheus-k8s",namespace="monitoring-satellite"}[5m], 60 * 30)
+          >
+            min_over_time(prometheus_notifications_queue_capacity{job="prometheus-k8s",namespace="monitoring-satellite"}[5m])
+          )
+        for: 15m
+        labels:
+          severity: warning
+      - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
+        annotations:
+          description: '{{ printf "%.1f" $value }}% errors while sending alerts from Prometheus {{$labels.namespace}}/{{$labels.pod}} to Alertmanager {{$labels.alertmanager}}.'
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusErrorSendingAlertsToSomeAlertmanagers.md
+          summary: Prometheus has encountered more than 1% errors sending alerts to a specific Alertmanager.
+        expr: |
+          (
+            rate(prometheus_notifications_errors_total{job="prometheus-k8s",namespace="monitoring-satellite"}[5m])
+          /
+            rate(prometheus_notifications_sent_total{job="prometheus-k8s",namespace="monitoring-satellite"}[5m])
+          )
+          * 100
+          > 1
+        for: 15m
+        labels:
+          severity: warning
+      - alert: PrometheusNotConnectedToAlertmanagers
+        annotations:
+          description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected to any Alertmanagers.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusNotConnectedToAlertmanagers.md
+          summary: Prometheus is not connected to any Alertmanagers.
+        expr: |
+          # Without max_over_time, failed scrapes could create false negatives, see
+          # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+          max_over_time(prometheus_notifications_alertmanagers_discovered{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]) < 1
+        for: 10m
+        labels:
+          severity: warning
+      - alert: PrometheusTSDBReloadsFailing
+        annotations:
+          description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected {{$value | humanize}} reload failures over the last 3h.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusTSDBReloadsFailing.md
+          summary: Prometheus has issues reloading blocks from disk.
+        expr: |
+          increase(prometheus_tsdb_reloads_failures_total{job="prometheus-k8s",namespace="monitoring-satellite"}[3h]) > 0
+        for: 4h
+        labels:
+          severity: warning
+      - alert: PrometheusTSDBCompactionsFailing
+        annotations:
+          description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected {{$value | humanize}} compaction failures over the last 3h.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusTSDBCompactionsFailing.md
+          summary: Prometheus has issues compacting blocks.
+        expr: |
+          increase(prometheus_tsdb_compactions_failed_total{job="prometheus-k8s",namespace="monitoring-satellite"}[3h]) > 0
+        for: 4h
+        labels:
+          severity: warning
+      - alert: PrometheusNotIngestingSamples
+        annotations:
+          description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting samples.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusNotIngestingSamples.md
+          summary: Prometheus is not ingesting samples.
+        expr: |
+          (
+            rate(prometheus_tsdb_head_samples_appended_total{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]) <= 0
+          and
+            (
+              sum without(scrape_job) (prometheus_target_metadata_cache_entries{job="prometheus-k8s",namespace="monitoring-satellite"}) > 0
+            or
+              sum without(rule_group) (prometheus_rule_group_rules{job="prometheus-k8s",namespace="monitoring-satellite"}) > 0
+            )
+          )
+        for: 10m
+        labels:
+          severity: warning
+      - alert: PrometheusDuplicateTimestamps
+        annotations:
+          description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping {{ printf "%.4g" $value  }} samples/s with different values but duplicated timestamp.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusDuplicateTimestamps.md
+          summary: Prometheus is dropping samples with duplicate timestamps.
+        expr: |
+          rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]) > 0
+        for: 10m
+        labels:
+          severity: warning
+      - alert: PrometheusOutOfOrderTimestamps
+        annotations:
+          description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping {{ printf "%.4g" $value  }} samples/s with timestamps arriving out of order.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusOutOfOrderTimestamps.md
+          summary: Prometheus drops samples with out-of-order timestamps.
+        expr: |
+          rate(prometheus_target_scrapes_sample_out_of_order_total{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]) > 0
+        for: 10m
+        labels:
+          severity: warning
+      - alert: PrometheusRemoteStorageFailures
+        annotations:
+          description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to send {{ printf "%.1f" $value }}% of the samples to {{ $labels.remote_name}}:{{ $labels.url }}
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusRemoteStorageFailures.md
+          summary: Prometheus fails to send samples to remote storage.
+        expr: |
+          (
+            (rate(prometheus_remote_storage_failed_samples_total{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]))
+          /
+            (
+              (rate(prometheus_remote_storage_failed_samples_total{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]))
+            +
+              (rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]) or rate(prometheus_remote_storage_samples_total{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]))
+            )
+          )
+          * 100
+          > 1
+        for: 15m
+        labels:
+          severity: critical
+      - alert: PrometheusRemoteWriteBehind
+        annotations:
+          description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write is {{ printf "%.1f" $value }}s behind for {{ $labels.remote_name}}:{{ $labels.url }}.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusRemoteWriteBehind.md
+          summary: Prometheus remote write is behind.
+        expr: |
+          # Without max_over_time, failed scrapes could create false negatives, see
+          # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+          (
+            max_over_time(prometheus_remote_storage_highest_timestamp_in_seconds{job="prometheus-k8s",namespace="monitoring-satellite"}[5m])
+          - ignoring(remote_name, url) group_right
+            max_over_time(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{job="prometheus-k8s",namespace="monitoring-satellite"}[5m])
+          )
+          > 120
+        for: 15m
+        labels:
+          severity: critical
+      - alert: PrometheusRemoteWriteDesiredShards
+        annotations:
+          description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write desired shards calculation wants to run {{ $value }} shards for queue {{ $labels.remote_name}}:{{ $labels.url }}, which is more than the max of {{ printf `prometheus_remote_storage_shards_max{instance="%s",job="prometheus-k8s",namespace="monitoring-satellite"}` $labels.instance | query | first | value }}.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusRemoteWriteDesiredShards.md
+          summary: Prometheus remote write desired shards calculation wants to run more than configured max shards.
+        expr: |
+          # Without max_over_time, failed scrapes could create false negatives, see
+          # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+          (
+            max_over_time(prometheus_remote_storage_shards_desired{job="prometheus-k8s",namespace="monitoring-satellite"}[5m])
+          >
+            max_over_time(prometheus_remote_storage_shards_max{job="prometheus-k8s",namespace="monitoring-satellite"}[5m])
+          )
+        for: 15m
+        labels:
+          severity: warning
+      - alert: PrometheusRuleFailures
+        annotations:
+          description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed to evaluate {{ printf "%.0f" $value }} rules in the last 5m.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusRuleFailures.md
+          summary: Prometheus is failing rule evaluations.
+        expr: |
+          increase(prometheus_rule_evaluation_failures_total{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]) > 0
+        for: 15m
+        labels:
+          severity: warning
+      - alert: PrometheusMissingRuleEvaluations
+        annotations:
+          description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed {{ printf "%.0f" $value }} rule group evaluations in the last 5m.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusMissingRuleEvaluations.md
+          summary: Prometheus is missing rule evaluations due to slow rule group evaluation.
+        expr: |
+          increase(prometheus_rule_group_iterations_missed_total{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]) > 0
+        for: 15m
+        labels:
+          severity: warning
+      - alert: PrometheusTargetLimitHit
+        annotations:
+          description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped {{ printf "%.0f" $value }} targets because the number of targets exceeded the configured target_limit.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusTargetLimitHit.md
+          summary: Prometheus has dropped targets because some scrape configs have exceeded the targets limit.
+        expr: |
+          increase(prometheus_target_scrape_pool_exceeded_target_limit_total{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]) > 0
+        for: 15m
+        labels:
+          severity: warning
+      - alert: PrometheusLabelLimitHit
+        annotations:
+          description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has dropped {{ printf "%.0f" $value }} targets because some samples exceeded the configured label_limit, label_name_length_limit or label_value_length_limit.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusLabelLimitHit.md
+          summary: Prometheus has dropped targets because some scrape configs have exceeded the labels limit.
+        expr: |
+          increase(prometheus_target_scrape_pool_exceeded_label_limits_total{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]) > 0
+        for: 15m
+        labels:
+          severity: warning
+      - alert: PrometheusScrapeBodySizeLimitHit
+        annotations:
+          description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed {{ printf "%.0f" $value }} scrapes in the last 5m because some targets exceeded the configured body_size_limit.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusScrapeBodySizeLimitHit.md
+          summary: Prometheus has dropped some targets that exceeded body size limit.
+        expr: |
+          increase(prometheus_target_scrapes_exceeded_body_size_limit_total{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]) > 0
+        for: 15m
+        labels:
+          severity: warning
+      - alert: PrometheusScrapeSampleLimitHit
+        annotations:
+          description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed {{ printf "%.0f" $value }} scrapes in the last 5m because some targets exceeded the configured sample_limit.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusScrapeSampleLimitHit.md
+          summary: Prometheus has failed scrapes that have exceeded the configured sample limit.
+        expr: |
+          increase(prometheus_target_scrapes_exceeded_sample_limit_total{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]) > 0
+        for: 15m
+        labels:
+          severity: warning
+      - alert: PrometheusTargetSyncFailure
+        annotations:
+          description: '{{ printf "%.0f" $value }} targets in Prometheus {{$labels.namespace}}/{{$labels.pod}} have failed to sync because invalid configuration was supplied.'
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusTargetSyncFailure.md
+          summary: Prometheus has failed to sync targets.
+        expr: |
+          increase(prometheus_target_sync_failed_total{job="prometheus-k8s",namespace="monitoring-satellite"}[30m]) > 0
+        for: 5m
+        labels:
+          severity: critical
+      - alert: PrometheusHighQueryLoad
+        annotations:
+          description: Prometheus {{$labels.namespace}}/{{$labels.pod}} query API has less than 20% available capacity in its query engine for the last 15 minutes.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusHighQueryLoad.md
+          summary: Prometheus is reaching its maximum capacity serving concurrent requests.
+        expr: |
+          avg_over_time(prometheus_engine_queries{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]) / max_over_time(prometheus_engine_queries_concurrent_max{job="prometheus-k8s",namespace="monitoring-satellite"}[5m]) > 0.8
+        for: 15m
+        labels:
+          severity: warning
+      - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
+        annotations:
+          description: '{{ printf "%.1f" $value }}% minimum errors while sending alerts from Prometheus {{$labels.namespace}}/{{$labels.pod}} to any Alertmanager.'
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusErrorSendingAlertsToAnyAlertmanager.md
+          summary: Prometheus encounters more than 3% errors sending alerts to any Alertmanager.
+        expr: |
+          min without (alertmanager) (
+            rate(prometheus_notifications_errors_total{job="prometheus-k8s",namespace="monitoring-satellite",alertmanager!~``}[5m])
+          /
+            rate(prometheus_notifications_sent_total{job="prometheus-k8s",namespace="monitoring-satellite",alertmanager!~``}[5m])
+          )
+          * 100
+          > 3
+        for: 15m
+        labels:
+          severity: critical
+    - name: prometheus-operator
+      rules:
+      - alert: PrometheusOperatorListErrors
+        annotations:
+          description: Errors while performing List operations in controller {{$labels.controller}} in {{$labels.namespace}} namespace.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusOperatorListErrors.md
+          summary: Errors while performing list operations in controller.
+        expr: |
+          (sum by (controller,namespace) (rate(prometheus_operator_list_operations_failed_total{job="prometheus-operator",namespace="monitoring-satellite"}[10m])) / sum by (controller,namespace) (rate(prometheus_operator_list_operations_total{job="prometheus-operator",namespace="monitoring-satellite"}[10m]))) > 0.4
+        for: 15m
+        labels:
+          severity: warning
+      - alert: PrometheusOperatorWatchErrors
+        annotations:
+          description: Errors while performing watch operations in controller {{$labels.controller}} in {{$labels.namespace}} namespace.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusOperatorWatchErrors.md
+          summary: Errors while performing watch operations in controller.
+        expr: |
+          (sum by (controller,namespace) (rate(prometheus_operator_watch_operations_failed_total{job="prometheus-operator",namespace="monitoring-satellite"}[5m])) / sum by (controller,namespace) (rate(prometheus_operator_watch_operations_total{job="prometheus-operator",namespace="monitoring-satellite"}[5m]))) > 0.4
+        for: 15m
+        labels:
+          severity: warning
+      - alert: PrometheusOperatorSyncFailed
+        annotations:
+          description: Controller {{ $labels.controller }} in {{ $labels.namespace }} namespace fails to reconcile {{ $value }} objects.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusOperatorSyncFailed.md
+          summary: Last controller reconciliation failed
+        expr: |
+          min_over_time(prometheus_operator_syncs{status="failed",job="prometheus-operator",namespace="monitoring-satellite"}[5m]) > 0
+        for: 10m
+        labels:
+          severity: warning
+      - alert: PrometheusOperatorReconcileErrors
+        annotations:
+          description: '{{ $value | humanizePercentage }} of reconciling operations failed for {{ $labels.controller }} controller in {{ $labels.namespace }} namespace.'
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusOperatorReconcileErrors.md
+          summary: Errors while reconciling controller.
+        expr: |
+          (sum by (controller,namespace) (rate(prometheus_operator_reconcile_errors_total{job="prometheus-operator",namespace="monitoring-satellite"}[5m]))) / (sum by (controller,namespace) (rate(prometheus_operator_reconcile_operations_total{job="prometheus-operator",namespace="monitoring-satellite"}[5m]))) > 0.1
+        for: 10m
+        labels:
+          severity: warning
+      - alert: PrometheusOperatorNodeLookupErrors
+        annotations:
+          description: Errors while reconciling Prometheus in {{ $labels.namespace }} Namespace.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusOperatorNodeLookupErrors.md
+          summary: Errors while reconciling Prometheus.
+        expr: |
+          rate(prometheus_operator_node_address_lookup_errors_total{job="prometheus-operator",namespace="monitoring-satellite"}[5m]) > 0.1
+        for: 10m
+        labels:
+          severity: warning
+      - alert: PrometheusOperatorNotReady
+        annotations:
+          description: Prometheus operator in {{ $labels.namespace }} namespace isn't ready to reconcile {{ $labels.controller }} resources.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusOperatorNotReady.md
+          summary: Prometheus operator not ready
+        expr: |
+          min by (controller,namespace) (max_over_time(prometheus_operator_ready{job="prometheus-operator",namespace="monitoring-satellite"}[5m]) == 0)
+        for: 5m
+        labels:
+          severity: warning
+      - alert: PrometheusOperatorRejectedResources
+        annotations:
+          description: Prometheus operator in {{ $labels.namespace }} namespace rejected {{ printf "%0.0f" $value }} {{ $labels.controller }}/{{ $labels.resource }} resources.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PrometheusOperatorRejectedResources.md
+          summary: Resources rejected by Prometheus operator
+        expr: |
+          min_over_time(prometheus_operator_managed_resources{state="rejected",job="prometheus-operator",namespace="monitoring-satellite"}[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+    - name: config-reloaders
+      rules:
+      - alert: ConfigReloaderSidecarErrors
+        annotations:
+          description: |-
+            Errors encountered while the {{$labels.pod}} config-reloader sidecar attempts to sync config in {{$labels.namespace}} namespace.
+            As a result, configuration for service running in {{$labels.pod}} may be stale and cannot be updated anymore.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/ConfigReloaderSidecarErrors.md
+          summary: config-reloader sidecar has not had a successful reload for 10m
+        expr: |
+          max_over_time(reloader_last_reload_successful{namespace=~".+"}[5m]) == 0
+        for: 10m
+        labels:
+          severity: warning
+    - name: cert-manager
+      rules:
+      - alert: CertManagerAbsent
+        annotations:
+          description: New certificates will not be able to be minted, and existing ones can't be renewed until cert-manager is back.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/CertManagerAbsent.md
+          summary: Cert Manager has dissapeared from Prometheus service discovery.
+        expr: absent(up{job="certmanager"})
+        for: 10m
+        labels:
+          severity: critical
+    - name: certificates
+      rules:
+      - alert: CertManagerCertExpirySoon
+        annotations:
+          dashboard_url: https://grafana.example.com/d/TvuRo2iMk/cert-manager
+          description: The domain that this cert covers will be unavailable after {{ $value | humanizeDuration }}. Clients using endpoints that this cert protects will start to fail in {{ $value | humanizeDuration }}.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/CertManagerCertExpirySoon.md
+          summary: The cert `{{ $labels.name }}` is {{ $value | humanizeDuration }} from expiry, it should have renewed over a week ago.
+        expr: |
+          avg by (exported_namespace, namespace, name) (
+            certmanager_certificate_expiration_timestamp_seconds - time()
+          ) < (7 * 24 * 3600) # 21 days in seconds
+        for: 1h
+        labels:
+          severity: warning
+      - alert: CertManagerCertNotReady
+        annotations:
+          dashboard_url: https://grafana.example.com/d/TvuRo2iMk/cert-manager
+          description: This certificate has not been ready to serve traffic for at least 10m. If the cert is being renewed or there is another valid cert, the ingress controller _may_ be able to serve that instead.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/CertManagerCertNotReady.md
+          summary: The cert `{{ $labels.name }}` is not ready to serve traffic.
+        expr: |
+          max by (name, exported_namespace, namespace, condition) (
+            certmanager_certificate_ready_status{condition!="True"} == 1
+          )
+        for: 10m
+        labels:
+          severity: critical
+      - alert: CertManagerHittingRateLimits
+        annotations:
+          dashboard_url: https://grafana.example.com/d/TvuRo2iMk/cert-manager
+          description: Depending on the rate limit, cert-manager may be unable to generate certificates for up to a week.
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/CertManagerHittingRateLimits.md
+          summary: Cert manager hitting LetsEncrypt rate limits.
+        expr: |
+          sum by (host) (
+            rate(certmanager_http_acme_client_request_count{status="429"}[5m])
+          ) > 0
+        for: 5m
+        labels:
+          severity: critical

--- a/monitoring-satellite/manifests/rules.jsonnet
+++ b/monitoring-satellite/manifests/rules.jsonnet
@@ -1,17 +1,28 @@
-// This file is used to generate YAMLs for testing purposes.
+// This file is used to generate all Prometheus recording and alerting rules from kube-prometheus.
+// It is then imported to our CLI installer using a YAML Importer.
+// This strategy is not supposed to last long, our long term vision is that we'll slowly delete unnecessary
+// alerts and we'll create and maintain our alerting rules ourselves.
 local monitoringSatellite = (import '../monitoring-satellite.libsonnet');
 
 local rules = {
-  groups+: monitoringSatellite.kubePrometheus.prometheusRule.spec.groups +
-           monitoringSatellite.alertmanager.prometheusRule.spec.groups +
-           monitoringSatellite.gitpod.prometheusRule.spec.groups +
-           monitoringSatellite.kubeStateMetrics.prometheusRule.spec.groups +
-           monitoringSatellite.kubernetesControlPlane.prometheusRule.spec.groups +
-           monitoringSatellite.nodeExporter.prometheusRule.spec.groups +
-           monitoringSatellite.prometheus.prometheusRule.spec.groups +
-           monitoringSatellite.prometheusOperator.prometheusRule.spec.groups +
-           monitoringSatellite.certmanager.prometheusRule.spec.groups,
-}
-;
+  prometheusRule: {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'PrometheusRule',
+    metadata: {
+      name: 'kube-prometheus-rules',
+      namespace: 'monitoring-satellite',
+    },
+    spec: {
+      groups: monitoringSatellite.kubePrometheus.prometheusRule.spec.groups +
+              monitoringSatellite.alertmanager.prometheusRule.spec.groups +
+              monitoringSatellite.kubeStateMetrics.prometheusRule.spec.groups +
+              monitoringSatellite.kubernetesControlPlane.prometheusRule.spec.groups +
+              monitoringSatellite.nodeExporter.prometheusRule.spec.groups +
+              monitoringSatellite.prometheus.prometheusRule.spec.groups +
+              monitoringSatellite.prometheusOperator.prometheusRule.spec.groups +
+              monitoringSatellite.certmanager.prometheusRule.spec.groups,
+    },
+  },
+};
 
-{ ci_prometheus_rules: rules }
+{ 'kube-prometheus-rules/rules': rules }


### PR DESCRIPTION
Fixes #254 

The strategy I used was to generate the YAML manifest and use the YAML importer.

Translating all the rules into go doesn't make much sense since our plan is to start deleting everything that is unnecessary and start maintain alerts ourselves.