### PR TITLE
Use different names for k8s service monitors

### DIFF
--- a/installer/pkg/components/kubernetes/apiserver.go
+++ b/installer/pkg/components/kubernetes/apiserver.go
@@ -1,6 +1,8 @@
 package kubernetes
 
 import (
+	"fmt"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -22,7 +24,7 @@ func serviceMonitorAPIServer(ctx *common.RenderContext) ([]runtime.Object, error
 				Kind:       "ServiceMonitor",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Name,
+				Name:      fmt.Sprintf("%s-apiserver", Name),
 				Namespace: Namespace,
 				Labels:    labels,
 			},

--- a/installer/pkg/components/kubernetes/kubelet.go
+++ b/installer/pkg/components/kubernetes/kubelet.go
@@ -1,6 +1,8 @@
 package kubernetes
 
 import (
+	"fmt"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -22,7 +24,7 @@ func serviceMonitorKubelet(ctx *common.RenderContext) ([]runtime.Object, error) 
 				Kind:       "ServiceMonitor",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      Name,
+				Name:      fmt.Sprintf("%s-kubelet", Name),
 				Namespace: Namespace,
 				Labels:    labels,
 			},


### PR DESCRIPTION
Small mistake in https://github.com/gitpod-io/observability/pull/259, I used the same name for both ServiceMonitors

![image](https://user-images.githubusercontent.com/24193764/184716266-5879e4aa-8f00-4908-addd-e219d03fd8ad.png)
