### PR TITLE
Update Prometheus and Alertmanager's service with correct label selectors

### DIFF
--- a/installer/pkg/components/alertmanager/service.go
+++ b/installer/pkg/components/alertmanager/service.go
@@ -34,7 +34,9 @@ func service(ctx *common.RenderContext) ([]runtime.Object, error) {
 						TargetPort: intstr.FromString("reloader-web"),
 					},
 				},
-				Selector: common.Labels(Name, Component, App, Version),
+				Selector: map[string]string{
+					"app.kubernetes.io/name": "alertmanager",
+				},
 			},
 		},
 	}, nil

--- a/installer/pkg/components/prometheus/service.go
+++ b/installer/pkg/components/prometheus/service.go
@@ -34,7 +34,9 @@ func service(ctx *common.RenderContext) ([]runtime.Object, error) {
 						TargetPort: intstr.FromString("reloader-web"),
 					},
 				},
-				Selector: common.Labels(Name, Component, App, Version),
+				Selector: map[string]string{
+					"app.kubernetes.io/name": "prometheus",
+				},
 			},
 		},
 	}, nil


### PR DESCRIPTION
Oof, that was a hard one to crack.

Although we set the label "app.kubernetes.io/name", prometheus-operator overrides this label with a hardcoded one:

See also:
https://github.com/prometheus-operator/prometheus-operator/blob/9f64561535810a9a3e4862beeb72577044be993f/pkg/prometheus/statefulset.go#L683-L690
https://github.com/prometheus-operator/prometheus-operator/blob/9f64561535810a9a3e4862beeb72577044be993f/pkg/alertmanager/statefulset.go#L338-L343


Fixes #253 