### PR TITLE
Remove unnecessary secret encoding

### DIFF
--- a/installer/pkg/components/prometheus/prometheus.go
+++ b/installer/pkg/components/prometheus/prometheus.go
@@ -1,7 +1,6 @@
 package prometheus
 
 import (
-	"encoding/base64"
 	"fmt"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -82,8 +81,8 @@ func remoteWriteSecrets(ctx *common.RenderContext) []runtime.Object {
 				Labels:    common.Labels(Name, Component, App, Version),
 			},
 			StringData: map[string]string{
-				"password": base64.StdEncoding.EncodeToString([]byte(rw.Password)),
-				"username": base64.StdEncoding.EncodeToString([]byte(rw.Username)),
+				"password": rw.Password,
+				"username": rw.Username,
 			},
 		})
 	}


### PR DESCRIPTION
I was making sure that the secrets generated for remote-write were correct and I was impressed to notice that they are double encoded. I believe k8s client-go already encodes it and we don't need to worry about it.

The expected password is set [here](https://github.com/gitpod-io/ops/blob/b5c443516b9fa1811cbbbe309c9bcf16161e40f8/deploy/staging/meta-us02/argocd/monitoring-satellite.yaml#L48)

![image](https://user-images.githubusercontent.com/24193764/184756293-03ebdecc-6dc0-4ad8-baf1-bad1c59179c6.png)

---

This PR removes one level of encoding.