### PR TITLE
Implement declarative imports from config file

### DIFF
--- a/installer/cmd/render.go
+++ b/installer/cmd/render.go
@@ -158,6 +158,16 @@ func renderKubernetesObjects(cfg *config.Config) ([]string, error) {
 		output = append(output, fmt.Sprintf("---\n# %s/%s %s\n%s", c.TypeMeta.APIVersion, c.TypeMeta.Kind, c.Metadata.Name, c.Content))
 	}
 
+	for _, imp := range ctx.Config.Imports.Kustomize {
+		kImporter := importer.NewKustomizeImporter(imp.GitURL, imp.Path)
+		output = append(output, kImporter.Import()...)
+	}
+
+	for _, imp := range ctx.Config.Imports.YAML {
+		yImporter := importer.NewYAMLImporter(imp.GitURL, imp.Path)
+		output = append(output, yImporter.Import()...)
+	}
+
 	if ctx.Config.Kubescape.Install {
 		kubescapeImporter := importer.NewYAMLImporter("https://github.com/gitpod-io/observability", "monitoring-satellite/manifests/kubescape")
 		output = append(output, kubescapeImporter.Import()...)

--- a/installer/cmd/render.go
+++ b/installer/cmd/render.go
@@ -176,6 +176,9 @@ func renderKubernetesObjects(cfg *config.Config) ([]string, error) {
 	kubePrometheusRulesImporter := importer.NewYAMLImporter("https://github.com/gitpod-io/observability", "monitoring-satellite/manifests/kube-prometheus-rules")
 	output = append(output, kubePrometheusRulesImporter.Import()...)
 
+	mixinImporter := importer.NewMixinImporter("https://github.com/gitpod-io/observability", "")
+	output = append(output, mixinImporter.ImportPrometheusRules()...)
+
 	return output, nil
 }
 

--- a/installer/cmd/render.go
+++ b/installer/cmd/render.go
@@ -168,23 +168,10 @@ func renderKubernetesObjects(cfg *config.Config) ([]string, error) {
 		output = append(output, yImporter.Import()...)
 	}
 
-	if ctx.Config.Kubescape.Install {
-		kubescapeImporter := importer.NewYAMLImporter("https://github.com/gitpod-io/observability", "monitoring-satellite/manifests/kubescape")
-		output = append(output, kubescapeImporter.Import()...)
-	}
-
 	if ctx.Config.Grafana.Install {
 		grafanaImporter := importer.NewYAMLImporter("https://github.com/gitpod-io/observability", "monitoring-satellite/manifests/grafana")
 		output = append(output, grafanaImporter.Import()...)
 	}
-
-	if ctx.Config.Prober.Install {
-		proberImporter := importer.NewYAMLImporter("https://github.com/gitpod-io/observability", "monitoring-satellite/manifests/probers")
-		output = append(output, proberImporter.Import()...)
-	}
-
-	kubePrometheusRulesImporter := importer.NewYAMLImporter("https://github.com/gitpod-io/observability", "monitoring-satellite/manifests/kube-prometheus-rules")
-	output = append(output, kubePrometheusRulesImporter.Import()...)
 
 	mixinImporter := importer.NewMixinImporter("https://github.com/gitpod-io/observability", "")
 	output = append(output, mixinImporter.ImportPrometheusRules()...)

--- a/installer/examples/default-config.yaml
+++ b/installer/examples/default-config.yaml
@@ -7,6 +7,7 @@ gitpod:
   installServiceMonitors: true
 grafana:
   install: false
+imports: {}
 kubescape:
   install: false
 namespace: monitoring-satellite

--- a/installer/examples/full-config.yaml
+++ b/installer/examples/full-config.yaml
@@ -49,3 +49,7 @@ imports:
   yaml:
     - gitURL: https://github.com/gitpod-io/observability
       path: monitoring-satellite/manifests/kube-prometheus-rules
+    - gitURL: https://github.com/gitpod-io/observability
+      path: monitoring-satellite/manifests/kubescape
+    - gitURL: https://github.com/gitpod-io/observability
+      path: monitoring-satellite/manifests/probers

--- a/installer/examples/full-config.yaml
+++ b/installer/examples/full-config.yaml
@@ -45,3 +45,7 @@ tracing:
   honeycombAPIKey: "fake-key"
 werft:
   installServiceMonitors: false
+imports:
+  yaml:
+    - gitURL: https://github.com/gitpod-io/observability
+      path: monitoring-satellite/manifests/kube-prometheus-rules

--- a/installer/examples/full-config.yaml
+++ b/installer/examples/full-config.yaml
@@ -29,8 +29,6 @@ grafana:
 kubescape:
   install: true
 namespace: monitoring-satellite
-prober:
-  install: true
 prometheus:
   remoteWrite:
   - password: password
@@ -49,7 +47,5 @@ imports:
   yaml:
     - gitURL: https://github.com/gitpod-io/observability
       path: monitoring-satellite/manifests/kube-prometheus-rules
-    - gitURL: https://github.com/gitpod-io/observability
-      path: monitoring-satellite/manifests/kubescape
     - gitURL: https://github.com/gitpod-io/observability
       path: monitoring-satellite/manifests/probers

--- a/installer/go.mod
+++ b/installer/go.mod
@@ -129,7 +129,7 @@ require (
 	golang.org/x/net v0.0.0-20220809184613-07c6da5e1ced // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/klog/v2 v2.70.1 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/kustomize/api v0.12.1

--- a/installer/pkg/components/components.go
+++ b/installer/pkg/components/components.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gitpod-io/observability/installer/pkg/components/pyrra"
 	"github.com/gitpod-io/observability/installer/pkg/components/shared"
 	"github.com/gitpod-io/observability/installer/pkg/components/werft"
-	"github.com/gitpod-io/observability/installer/pkg/importer"
 )
 
 func MonitoringCentralObjects(ctx *common.RenderContext) common.RenderFunc {
@@ -22,12 +21,9 @@ func MonitoringCentralObjects(ctx *common.RenderContext) common.RenderFunc {
 }
 
 func MonitoringSatelliteObjects(ctx *common.RenderContext) common.RenderFunc {
-	mixinImporter := importer.NewMixinImporter("https://github.com/gitpod-io/observability", "")
-
 	return common.CompositeRenderFunc(
 		alertmanager.Objects,
 		kubestateMetrics.Objects,
-		mixinImporter.ImportPrometheusRules,
 		nodeExporter.Objects,
 		prometheusoperator.Objects,
 		otelCollector.Objects(ctx),

--- a/installer/pkg/config/config.go
+++ b/installer/pkg/config/config.go
@@ -7,6 +7,8 @@ package config
 import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gitpod-io/observability/installer/pkg/importer"
 )
 
 func Factory() interface{} {
@@ -61,6 +63,8 @@ func Defaults(in interface{}) error {
 		Install: false,
 	}
 
+	cfg.Imports = &Imports{}
+
 	cfg.Prometheus = &Prometheus{
 		RemoteWrite: []*RemoteWrite{
 			{
@@ -90,6 +94,7 @@ type Config struct {
 	Kubescape    *Kubescape        `json:"kubescape,omitempty"`
 	Grafana      *Grafana          `json:"grafana,omitempty"`
 	Certmanager  *Certmanager      `json:"certmanager,omitempty"`
+	Imports      *Imports          `json:"imports,omitempty"`
 }
 
 type Tracing struct {
@@ -150,4 +155,9 @@ type Grafana struct {
 
 type Certmanager struct {
 	InstallServiceMonitors bool `json:"installServiceMonitors"`
+}
+
+type Imports struct {
+	YAML      *[]importer.YAMLImporter      `json:"yaml,omitempty"`
+	Kustomize *[]importer.KustomizeImporter `json:"kustomize,omitempty"`
 }

--- a/installer/pkg/config/config.go
+++ b/installer/pkg/config/config.go
@@ -158,6 +158,6 @@ type Certmanager struct {
 }
 
 type Imports struct {
-	YAML      *[]importer.YAMLImporter      `json:"yaml,omitempty"`
-	Kustomize *[]importer.KustomizeImporter `json:"kustomize,omitempty"`
+	YAML      []importer.YAMLImporter      `json:"yaml,omitempty"`
+	Kustomize []importer.KustomizeImporter `json:"kustomize,omitempty"`
 }

--- a/installer/pkg/importer/importer.go
+++ b/installer/pkg/importer/importer.go
@@ -11,19 +11,19 @@ const (
 	clonePath = "/tmp/clonedRepository"
 )
 
-type importer struct {
-	GitURL string
-	Path   string
+type Importer struct {
+	GitURL string `json:"gitURL"`
+	Path   string `json:"path"`
 }
 
-func newImporter(gitURL, path string) *importer {
-	return &importer{
+func newImporter(gitURL, path string) *Importer {
+	return &Importer{
 		GitURL: gitURL,
 		Path:   path,
 	}
 }
 
-func (i importer) cloneRepository() {
+func (i Importer) cloneRepository() {
 	os.RemoveAll(clonePath)
 	_, err := git.PlainClone(clonePath, false, &git.CloneOptions{
 		URL: i.GitURL,

--- a/installer/pkg/importer/importer.go
+++ b/installer/pkg/importer/importer.go
@@ -12,21 +12,21 @@ const (
 )
 
 type importer struct {
-	gitURL string
-	path   string
+	GitURL string
+	Path   string
 }
 
 func newImporter(gitURL, path string) *importer {
 	return &importer{
-		gitURL: gitURL,
-		path:   path,
+		GitURL: gitURL,
+		Path:   path,
 	}
 }
 
 func (i importer) cloneRepository() {
 	os.RemoveAll(clonePath)
 	_, err := git.PlainClone(clonePath, false, &git.CloneOptions{
-		URL: i.gitURL,
+		URL: i.GitURL,
 	})
 
 	if err != nil {

--- a/installer/pkg/importer/kustomize.go
+++ b/installer/pkg/importer/kustomize.go
@@ -13,12 +13,12 @@ import (
 // kustomizeImporter := NewKustomizeImporter("https://github.com/kubernetes-sigs/kustomize", "examples/helloWorld")
 // kustomizeImporter.Import()
 type KustomizeImporter struct {
-	*importer
+	*Importer
 }
 
 func NewKustomizeImporter(gitURL, path string) *KustomizeImporter {
 	return &KustomizeImporter{
-		importer: newImporter(gitURL, path),
+		Importer: newImporter(gitURL, path),
 	}
 }
 

--- a/installer/pkg/importer/kustomize.go
+++ b/installer/pkg/importer/kustomize.go
@@ -22,11 +22,11 @@ func NewKustomizeImporter(gitURL, path string) *KustomizeImporter {
 	}
 }
 
-func (k KustomizeImporter) Import() {
+func (k KustomizeImporter) Import() []string {
 	k.cloneRepository()
 
 	kustomize := krusty.MakeKustomizer(krusty.MakeDefaultOptions())
-	m, err := kustomize.Run(filesys.MakeFsOnDisk(), fmt.Sprintf("%s/%s", clonePath, k.path))
+	m, err := kustomize.Run(filesys.MakeFsOnDisk(), fmt.Sprintf("%s/%s", clonePath, k.Path))
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -36,5 +36,5 @@ func (k KustomizeImporter) Import() {
 		fmt.Println(err)
 	}
 
-	fmt.Println(string(yml))
+	return []string{string(yml)}
 }

--- a/installer/pkg/importer/mixin.go
+++ b/installer/pkg/importer/mixin.go
@@ -7,10 +7,8 @@ import (
 
 	"github.com/google/go-jsonnet"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
-	"github.com/gitpod-io/observability/installer/pkg/common"
 )
 
 var (
@@ -47,7 +45,7 @@ func NewMixinImporter(gitURL, path string) *MixinImporter {
 	}
 }
 
-func (m MixinImporter) ImportPrometheusRules(ctx *common.RenderContext) ([]runtime.Object, error) {
+func (m MixinImporter) ImportPrometheusRules() []string {
 	m.cloneRepository()
 
 	jsonnetImports := []string{platformMixinImport, ideMixinImport, webappMixinImport, workspaceMixinImport}
@@ -64,10 +62,10 @@ func (m MixinImporter) ImportPrometheusRules(ctx *common.RenderContext) ([]runti
 		fmt.Println(err)
 	}
 
-	return unmarshalMixinToRuntimeObject(out), nil
+	return []string{unmarshalMixinToYAML(out)}
 }
 
-func unmarshalMixinToRuntimeObject(j string) []runtime.Object {
+func unmarshalMixinToYAML(j string) string {
 	var result map[string]interface{}
 	err := json.Unmarshal([]byte(j), &result)
 	if err != nil {
@@ -87,18 +85,23 @@ func unmarshalMixinToRuntimeObject(j string) []runtime.Object {
 		fmt.Println(err)
 	}
 
-	return []runtime.Object{
-		&monitoringv1.PrometheusRule{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "monitoring.coreos.com/v1",
-				Kind:       "PrometheusRule",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "gitpod-monitoring-rules",
-				//TODO: get namespace from config
-				Namespace: "monitoring-satellite",
-			},
-			Spec: ruleSpec,
+	r := monitoringv1.PrometheusRule{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "monitoring.coreos.com/v1",
+			Kind:       "PrometheusRule",
 		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gitpod-monitoring-rules",
+			//TODO: get namespace from config
+			Namespace: "monitoring-satellite",
+		},
+		Spec: ruleSpec,
 	}
+
+	yamlData, err := yaml.Marshal(&r)
+	if err != nil {
+		fmt.Printf("Error while Marshaling. %v", err)
+	}
+
+	return string(yamlData)
 }

--- a/installer/pkg/importer/mixin.go
+++ b/installer/pkg/importer/mixin.go
@@ -36,12 +36,12 @@ var (
 //
 // The import snippet is hard-coded because the mixin importer is very specialized to the way mixins are organized internally at gitpod.
 type MixinImporter struct {
-	*importer
+	*Importer
 }
 
 func NewMixinImporter(gitURL, path string) *MixinImporter {
 	return &MixinImporter{
-		importer: newImporter(gitURL, path),
+		Importer: newImporter(gitURL, path),
 	}
 }
 

--- a/installer/pkg/importer/yaml.go
+++ b/installer/pkg/importer/yaml.go
@@ -46,7 +46,7 @@ func (y YAMLImporter) Import() []string {
 
 func (y YAMLImporter) getFiles() ([]string, error) {
 	var matches []string
-	err := filepath.Walk(fmt.Sprintf("%s/%s/", clonePath, y.path), func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(fmt.Sprintf("%s/%s/", clonePath, y.Path), func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/installer/pkg/importer/yaml.go
+++ b/installer/pkg/importer/yaml.go
@@ -15,12 +15,12 @@ const YAMLpattern = "*.yaml"
 // yamlImporter := importer.NewYAMLImporter("https://github.com/ArthurSens/observability", "manifests/production/meta/kubescape", false)
 // yamlImporter.Import()
 type YAMLImporter struct {
-	*importer
+	*Importer
 }
 
 func NewYAMLImporter(gitURL, path string) *YAMLImporter {
 	return &YAMLImporter{
-		importer: newImporter(gitURL, path),
+		Importer: newImporter(gitURL, path),
 	}
 }
 


### PR DESCRIPTION
As discussed during the last 2 or 3 team sync, we envision that this CLI will be capable of importing manifests from different git repositories and that components that are not part of the main observability stack will be imported with this strategy.

To ship things quickly, our first iteration hardcoded imports of core components, such as grafana, but we also hardcoded non-essential components, such as the http-prober that is only used in preview environments and kubescape which is only deployed in application clusters.

This PR adds an interface to our config file, so we can declare what we want to import.

---

To make a smoother transition, I'm not removing Kubescape and Prober from our Config interface, but sending a deprecation notice instead.

Once we adjusted our config to use the importer interface, we can remove the deprecation notice.