### PR TITLE
Remove kubescape and prober from tests

### DIFF
--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -48,7 +48,7 @@ func testMain(m *testing.M) int {
 func TestDeployments(t *testing.T) {
 	kClient := promClient.kubeClient
 
-	apps := []string{"grafana", "kube-state-metrics", "prometheus-operator", "otel-collector", "kubescape", "http-prober"}
+	apps := []string{"grafana", "kube-state-metrics", "prometheus-operator", "otel-collector"}
 
 	for _, app := range apps {
 		// Table-driven + parallel tests are quite tricky and require us


### PR DESCRIPTION
They are not part of our main stack anymore (we're encouraging to use importers), and the kubescape tests are flaky.

I believe we don't need to test them 🤔 