### PR TITLE
Remove kube-state-metrics alerts

### DIFF
--- a/lib/alert-filter.libsonnet
+++ b/lib/alert-filter.libsonnet
@@ -68,6 +68,11 @@ local unwatedAlerts = [
   'KubeletDown',  // Re-added to platform-mixin
   'KubeClientErrors',
 
+  // From kube-state-metrics
+  'KubeStateMetricsWatchErrors',  // Re-added to platform-mixin
+  'KubeStateMetricsShardingMismatch',
+  'KubeStateMetricsShardsMissing',
+
   // From prometheus-operator
   'PrometheusOperatorListErrors',  // Re-added to platform-mixin
   'PrometheusOperatorWatchErrors',  // Re-added to platform-mixin

--- a/monitoring-satellite/manifests/kube-prometheus-rules/rules.yaml
+++ b/monitoring-satellite/manifests/kube-prometheus-rules/rules.yaml
@@ -187,43 +187,7 @@ spec:
       labels:
         severity: critical
   - name: kube-state-metrics
-    rules:
-    - alert: KubeStateMetricsWatchErrors
-      annotations:
-        description: kube-state-metrics is experiencing errors at an elevated rate in watch operations. This is likely causing it to not be able to expose metrics about Kubernetes objects correctly or at all.
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeStateMetricsWatchErrors.md
-        summary: kube-state-metrics is experiencing errors in watch operations.
-      expr: |
-        (sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics",result="error"}[5m]))
-          /
-        sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics"}[5m])))
-        > 0.01
-      for: 15m
-      labels:
-        severity: critical
-    - alert: KubeStateMetricsShardingMismatch
-      annotations:
-        description: kube-state-metrics pods are running with different --total-shards configuration, some Kubernetes objects may be exposed multiple times or not exposed at all.
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeStateMetricsShardingMismatch.md
-        summary: kube-state-metrics sharding is misconfigured.
-      expr: |
-        stdvar (kube_state_metrics_total_shards{job="kube-state-metrics"}) != 0
-      for: 15m
-      labels:
-        severity: critical
-    - alert: KubeStateMetricsShardsMissing
-      annotations:
-        description: kube-state-metrics shards are missing, some Kubernetes objects are not being exposed.
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/KubeStateMetricsShardsMissing.md
-        summary: kube-state-metrics shards are missing.
-      expr: |
-        2^max(kube_state_metrics_total_shards{job="kube-state-metrics"}) - 1
-          -
-        sum( 2 ^ max by (shard_ordinal) (kube_state_metrics_shard_ordinal{job="kube-state-metrics"}) )
-        != 0
-      for: 15m
-      labels:
-        severity: critical
+    rules: []
   - name: kubernetes-apps
     rules: []
   - name: kubernetes-resources


### PR DESCRIPTION
Removes all alerts coming from the kube-state-metrics mixin.

The ones useful to us will be recreated in the gitpod-mixin