### PR TITLE
Remove duplicate env vars in grafana deployment

### DIFF
--- a/monitoring-satellite/manifests/grafana/deployment.yaml
+++ b/monitoring-satellite/manifests/grafana/deployment.yaml
@@ -36,12 +36,6 @@ spec:
           value: Admin
         - name: GF_AUTH_DISABLE_LOGIN_FORM
           value: "true"
-        - name: GF_AUTH_ANONYMOUS_ENABLED
-          value: "true"
-        - name: GF_AUTH_ANONYMOUS_ORG_ROLE
-          value: Admin
-        - name: GF_AUTH_DISABLE_LOGIN_FORM
-          value: "true"
         image: grafana/grafana:9.1.1
         name: grafana
         ports:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes
```bash
Error from server: failed to create typed patch object (monitoring-satellite/grafana; apps/v1, Kind=Deployment): errors:
  .spec.template.spec.containers[name="grafana"].env: duplicate entries for key [name="GF_AUTH_ANONYMOUS_ENABLED"]
  .spec.template.spec.containers[name="grafana"].env: duplicate entries for key [name="GF_AUTH_ANONYMOUS_ORG_ROLE"]
  .spec.template.spec.containers[name="grafana"].env: duplicate entries for key [name="GF_AUTH_DISABLE_LOGIN_FORM"]
```

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
