### PR TITLE
Revert "Revert "Remove duplicate env vars in grafana jsonnet""

### DIFF
--- a/addons/disable-grafana-auth.libsonnet
+++ b/addons/disable-grafana-auth.libsonnet
@@ -1,7 +1,7 @@
 {
   values+:: {
     grafana+: {
-      env+: [
+      env: [
         {
           name: 'GF_AUTH_ANONYMOUS_ENABLED',
           value: 'true',

--- a/monitoring-satellite/manifests/grafana/deployment.yaml
+++ b/monitoring-satellite/manifests/grafana/deployment.yaml
@@ -36,12 +36,6 @@ spec:
           value: Admin
         - name: GF_AUTH_DISABLE_LOGIN_FORM
           value: "true"
-        - name: GF_AUTH_ANONYMOUS_ENABLED
-          value: "true"
-        - name: GF_AUTH_ANONYMOUS_ORG_ROLE
-          value: Admin
-        - name: GF_AUTH_DISABLE_LOGIN_FORM
-          value: "true"
         image: grafana/grafana:9.1.1
         name: grafana
         ports:


### PR DESCRIPTION
I'm going to revert the revert and try again while it's early in the morning. It seems a known issue where k8s removes all duplicate env vars when you deduplicate them: https://github.com/kubernetes/kubernetes/issues/58477 , reapplying or patching should help. 

Verified it in staging.

Reverts gitpod-io/observability#306