### PR TITLE
Automatically release `obs-installer` binaries with incremental semver autotagging.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,49 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+
+env:
+  golang-version: "1.19"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+        # https://github.com/PaulHatch/semantic-version
+      - id: semver
+        uses: paulhatch/semantic-version@v4
+        with:
+          # The prefix to use to identify tags
+          tag_prefix: "v"
+          # A string which, if present in a git commit, indicates that a change represents a
+          # major (breaking) change, supports regular expressions wrapped with '/'
+          major_pattern: "(MAJOR)"
+          # Same as above except indicating a minor change, supports regular expressions wrapped with '/'
+          minor_pattern: "(MINOR)"
+          # A string to determine the format of the version output
+          format: "${major}.${minor}.${patch}-prerelease${increment}"
+          # Optional path to check for changes. If any changes are detected in the path the
+          # 'changed' output will true. Enter multiple paths separated by spaces.
+          change_path: "installer/"
+          # If this is set to true, *every* commit will be treated as a new version.
+          bump_each_commit: false
+      - uses: actions/setup-go@v2
+        if: ${{steps.semver.outputs.changed}}
+        with:
+          go-version: ${{ env.golang-version }}
+      - name: Build artifacts
+        if: ${{steps.semver.outputs.changed}}
+        run: VERSION=${{steps.semver.outputs.version_tag}} ./hack/build-obs-installer.sh
+        # https://github.com/softprops/action-gh-release
+      - uses: softprops/action-gh-release@v1
+        if: ${{steps.semver.outputs.changed}}
+        with:
+          tag_name: ${{steps.semver.outputs.version_tag}}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: ./installer/*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ diff
 !monitoring-satellite/manifests/probers/*
 !monitoring-satellite/manifests/kube-prometheus-rules/*
 !monitoring-satellite/manifests/crds/*
+
+*.tar.gz

--- a/hack/build-obs-installer.sh
+++ b/hack/build-obs-installer.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# shellcheck disable=SC2034
+
+set -euo pipefail
+
+SCRIPT_PATH=$(realpath "$(dirname "$0")")
+PROJECT_ROOT=$(realpath "${SCRIPT_PATH}/../")
+
+INSTALLER_DIR="${PROJECT_ROOT}/installer"
+BINARY_NAME="obs-installer"
+
+if [ -z ${VERSION+x} ]; then
+  echo "Must supply VERSION"
+fi
+
+pushd "${INSTALLER_DIR}"
+
+for GOOS in darwin linux; do
+  for GOARCH in arm64 amd64; do
+    export GOOS=$GOOS
+    export GOARCH=$GOARCH
+
+    RELEASE_NAME="${BINARY_NAME}_${VERSION}_${GOOS}_${GOARCH}.tar.gz"
+    echo "Building ${RELEASE_NAME}"
+
+    go build -o ${BINARY_NAME} .
+    tar cf "${RELEASE_NAME}" ${BINARY_NAME}
+    rm "${BINARY_NAME}"
+  done
+done
+
+popd


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Automatically release `obs-installer` binaries with incremental semver autotagging.

It will automatically create a tag based on the semver. If it detects `major/minor/patch` in the commit message it will accordingly increment. Otherwise will auto increment the patch version if it detects changes to files in `/installer` directory.

Example job: https://github.com/gitpod-io/observability/actions/runs/3068277487/jobs/4955549014
Example release: https://github.com/gitpod-io/observability/releases/tag/v0.0.3 - tag is on main, as we would like to do releases only on main. It happened through a job on this branch, due to me testing.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
