### PR TITLE
don't reset `jsonnetfile.lock.json` file while dependencies update

### DIFF
--- a/.github/workflows/dep-update.yaml
+++ b/.github/workflows/dep-update.yaml
@@ -19,11 +19,18 @@ jobs:
         with:
           go-version: 1.19
       - name: Update jsonnet dependencies
+        continue-on-error: true
         run: |
           make update
+          # Reset jsonnetfile.lock.json if no dependencies were updated
+          changedFiles=$(git diff --name-only | grep -v 'jsonnetfile.lock.json')
+          if [[ $changedFiles == "" ]]; then
+            git checkout -- jsonnetfile.lock.json;
+          fi
           make generate
 
       - name: Create Pull Request
+        continue-on-error: true
         uses: peter-evans/create-pull-request@v3
         id: cpr
         with:

--- a/.github/workflows/dep-update.yaml
+++ b/.github/workflows/dep-update.yaml
@@ -21,11 +21,6 @@ jobs:
       - name: Update jsonnet dependencies
         run: |
           make update
-          # Reset jsonnetfile.lock.json if no dependencies were updated
-          changedFiles=$(git diff --name-only | grep -v 'jsonnetfile.lock.json')
-          if [[ $changedFiles == "" ]]; then
-            git checkout -- jsonnetfile.lock.json;
-          fi
           make generate
 
       - name: Create Pull Request


### PR DESCRIPTION
## Description
Due to permission issues (maybe), it is unable to revert the changes. I think it is not required to revert `jsonnetfile.lock.json`.

Tested the [failed step - `Update jsonnet dependencies`](https://github.com/gitpod-io/observability/actions/runs/3080620387/jobs/4978472344) here [on my fork](https://github.com/Siddhant-K-code/observability/actions/runs/3081110358/jobs/4979276797). Working perfectly

Cause: Maybe someone changed [this setting](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/#setting-the-default-permissions-for-the-organization-or-repository)

## Related Issue(s)
Fixes [Internal Discussion](https://gitpod.slack.com/archives/C01KGM9EBD4/p1663572775177129)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No