### PR TITLE
Make it possible to add new span attributes through Otel-Collector

### DIFF
--- a/installer/examples/full-config.yaml
+++ b/installer/examples/full-config.yaml
@@ -28,6 +28,9 @@ tracing:
   install: true
   honeycombDataset: "fake-dataset"
   honeycombAPIKey: "fake-key"
+  extraSpanAttributes:
+    preview: test
+    exampleKey: exampleValue
 werft:
   installServiceMonitors: false
 imports:

--- a/installer/pkg/components/otel-collector/configmap.go
+++ b/installer/pkg/components/otel-collector/configmap.go
@@ -10,39 +10,20 @@ import (
 	"github.com/gitpod-io/observability/installer/pkg/common"
 )
 
-var configMapData = `receivers:
-  jaeger:
-    protocols:
-      thrift_http:
-        endpoint: "0.0.0.0:14268"
-  otlp:
-    protocols:
-      grpc: # on port 4317
-      http: # on port 4318
-exporters:
-  otlp:
-    endpoint: "api.honeycomb.io:443"
-    headers:
-      "x-honeycomb-team": "%s"
-      "x-honeycomb-dataset": "%s"
-
-extensions:
-  health_check:
-  pprof:
-  zpages:
-service:
-  telemetry:
-    logs:
-      level: "debug"
-  extensions: [health_check, pprof,  zpages]
-  pipelines:
-    traces:
-      receivers: [jaeger, otlp]
-      processors: [ ]
-      exporters: ["otlp"]
-`
+const extraAttributesProcessor = "attributes"
 
 func configMap(ctx *common.RenderContext) ([]runtime.Object, error) {
+	var receiversConfig = buildReceiversConfig(ctx)
+	var processorsConfig = buildProcessorsConfig(ctx)
+	var exportersConfig = buildExportersConfig(ctx)
+	var extensionsConfig = buildExtensionsConfig(ctx)
+	var serviceConfig = buildServiceConfig(ctx)
+	var config = fmt.Sprintf(`%s
+%s
+%s
+%s
+%s`, receiversConfig, processorsConfig, exportersConfig, extensionsConfig, serviceConfig)
+
 	return []runtime.Object{
 		&corev1.ConfigMap{
 			TypeMeta: metav1.TypeMeta{
@@ -55,8 +36,78 @@ func configMap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Labels:    common.Labels(Name, Component, App, Version),
 			},
 			Data: map[string]string{
-				"collector.yaml": fmt.Sprintf(configMapData, ctx.Config.Tracing.HoneycombAPIKey, ctx.Config.Tracing.HoneycombDataset),
+				"collector.yaml": config,
 			},
 		},
 	}, nil
+}
+
+func buildReceiversConfig(ctx *common.RenderContext) string {
+	return `receivers:
+  jaeger:
+    protocols:
+      thrift_http:
+        endpoint: "0.0.0.0:14268"
+  otlp:
+    protocols:
+      grpc: # on port 4317
+      http: # on port 4318
+`
+}
+
+func buildProcessorsConfig(ctx *common.RenderContext) string {
+	var processorsConfig = ""
+	if ctx.Config.Tracing.ExtraSpanAttributes != nil {
+		processorsConfig = fmt.Sprintf(`processors:
+  %s:
+    actions:`, extraAttributesProcessor)
+
+		var keyValueAttributeTemplate = `
+      - key: '%s'
+        value: %s
+        action: insert`
+		for key, value := range ctx.Config.Tracing.ExtraSpanAttributes {
+			processorsConfig += fmt.Sprintf(keyValueAttributeTemplate, key, value)
+		}
+	}
+
+	return processorsConfig
+}
+
+func buildExportersConfig(ctx *common.RenderContext) string {
+	return fmt.Sprintf(`exporters:
+  otlp:
+    endpoint: "api.honeycomb.io:443"
+    headers:
+      "x-honeycomb-team": "%s"
+      "x-honeycomb-dataset": "%s"`,
+		ctx.Config.Tracing.HoneycombAPIKey, ctx.Config.Tracing.HoneycombDataset)
+}
+
+func buildExtensionsConfig(ctx *common.RenderContext) string {
+	return `extensions:
+  health_check:
+  pprof:
+  zpages:`
+}
+
+func buildServiceConfig(ctx *common.RenderContext) string {
+	var serviceTemplate = `service:
+  telemetry:
+    logs:
+      level: "debug"
+  extensions: [health_check, pprof,  zpages]
+  pipelines:
+    traces:
+     receivers: [jaeger, otlp]
+     processors: [%s]
+     exporters: ["otlp"]
+`
+	var processors = ""
+
+	if ctx.Config.Tracing.ExtraSpanAttributes != nil {
+		processors = extraAttributesProcessor
+	}
+
+	return fmt.Sprintf(serviceTemplate, processors)
 }

--- a/installer/pkg/config/config.go
+++ b/installer/pkg/config/config.go
@@ -92,9 +92,10 @@ type Config struct {
 }
 
 type Tracing struct {
-	Install          bool   `json:"install"`
-	HoneycombAPIKey  string `json:"honeycombAPIKey,omitempty"`
-	HoneycombDataset string `json:"honeycombDataset,omitempty"`
+	Install             bool              `json:"install"`
+	HoneycombAPIKey     string            `json:"honeycombAPIKey,omitempty"`
+	HoneycombDataset    string            `json:"honeycombDataset,omitempty"`
+	ExtraSpanAttributes map[string]string `json:"extraSpanAttributes,omitempty"`
 }
 
 type Alerting struct {


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/observability/issues/308

---

## Summary

Essentially this PR splits the creation of the variable [ConfigMapData](https://github.com/gitpod-io/observability/blob/b626341177991d1946298f1326a5aa327f8090e7/installer/pkg/components/otel-collector/configmap.go#L13) into multiple small functions.

While building the [processor configuration](https://opentelemetry.io/docs/collector/configuration/#processors), it will check if the installer config asks for extra span attributes:
* No extra attributes means that the processor configuration will be empty
* If there is extra attributes to be added, the processor configuration will exist.

## How to test

You can open a workspace from this PR, then play around with the file `installer/examples/full-config.yaml` by adding or removing fields to `tracing.extraSpanAttributes` then running:
```
cd installer
make generate-full
```

This command will generate the file `installer/monitoring-satellite.yml`, and you'll notice that Otel-collector's configmap will be written as expected