### PR TITLE
Add flag that differentiates which app is going to be installed

### DIFF
--- a/installer/Makefile
+++ b/installer/Makefile
@@ -20,10 +20,10 @@ monitoring-satellite.yaml: generate-full
 
 generate: installer
 	./installer init > examples/default-config.yaml
-	./installer render --config examples/default-config.yaml > monitoring-satellite.yaml
+	./installer render --config examples/default-config.yaml --app monitoring-satellite > monitoring-satellite.yaml
 
 generate-full: installer
-	./installer render --config examples/full-config.yaml > monitoring-satellite.yaml
+	./installer render --config examples/full-config.yaml --app monitoring-satellite > monitoring-satellite.yaml
 
 .PHONY: deploy-satellite
 apply-satellite: monitoring-satellite.yaml

--- a/installer/pkg/config/loader.go
+++ b/installer/pkg/config/loader.go
@@ -26,7 +26,7 @@ var (
 	ErrInvalidType = fmt.Errorf("invalid type")
 )
 
-func Load(config string, strict bool) (cfg interface{}, err error) {
+func LoadSatellite(config string, strict bool) (cfg interface{}, err error) {
 	// Load default configuration
 	cfg = Factory()
 	err = Defaults(cfg)


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/ops/issues/5205

---

The PR adds a new flag(`--app`) to the CLI, where the only valid options are `monitoring-satellite` or `monitoring-central`. Everything is already configured to have a nice CLI experience (type validation, auto-completion).

When it comes to logic, the only change made was that when loading configuration, we have a `switch case` that checks which app was passed and loads the correct configuration. Right now only `monitoring-satellite` has the Config type implemented, if someone tries to render `monitoring-central` then nothing happens.

/hold since this PR needs some coordination to merge. We'll need to update everything that is currently using this CLI