### PR TITLE
fix: release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-paths
+    paths:
+      - 'installer/**'
 
 env:
   golang-version: "1.19"
@@ -18,19 +21,6 @@ jobs:
         # https://github.com/PaulHatch/semantic-version
       - id: semver
         uses: paulhatch/semantic-version@v5.0.0-alpha
-        with:
-          # The prefix to use to identify tags
-          tag_prefix: "v"
-          # A string which, if present in a git commit, indicates that a change represents a
-          # major (breaking) change, supports regular expressions wrapped with '/'
-          major_pattern: "(MAJOR)"
-          # A string to determine the format of the version output
-          format: "${major}"
-          # Optional path to check for changes. If any changes are detected in the path the
-          # 'changed' output will true. Enter multiple paths separated by spaces.
-          # change_path: "installer/"
-          # If this is set to true, *every* commit will be treated as a new version.
-          bump_each_commit: false
       - uses: actions/setup-go@v2
         if: ${{steps.semver.outputs.changed}}
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
         # https://github.com/PaulHatch/semantic-version
       - id: semver
-        uses: paulhatch/semantic-version@v4
+        uses: paulhatch/semantic-version@v5.0.0-alpha
         with:
           # The prefix to use to identify tags
           tag_prefix: "v"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,10 +23,8 @@ jobs:
           # A string which, if present in a git commit, indicates that a change represents a
           # major (breaking) change, supports regular expressions wrapped with '/'
           major_pattern: "(MAJOR)"
-          # Same as above except indicating a minor change, supports regular expressions wrapped with '/'
-          minor_pattern: "(MINOR)"
           # A string to determine the format of the version output
-          format: "${major}.${minor}.${patch}-prerelease${increment}"
+          format: "${major}"
           # Optional path to check for changes. If any changes are detected in the path the
           # 'changed' output will true. Enter multiple paths separated by spaces.
           change_path: "installer/"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
         # https://github.com/PaulHatch/semantic-version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,6 @@
 name: Release
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -27,7 +28,7 @@ jobs:
           format: "${major}"
           # Optional path to check for changes. If any changes are detected in the path the
           # 'changed' output will true. Enter multiple paths separated by spaces.
-          change_path: "installer/"
+          # change_path: "installer/"
           # If this is set to true, *every* commit will be treated as a new version.
           bump_each_commit: false
       - uses: actions/setup-go@v2


### PR DESCRIPTION
fixes #327 

---

## Description of changes

- Added `workflow_dispatch` so that we can manually run If release pipelines fail sometimes. or in any other case
- Updated to `checkout@v3`, not a required change. But things should be updated to LTS.
- Updated to `paulhatch/semantic-version@v5.0.0-alpha` which fixes all our pain of weird versioning, not working in forks, etc.
- Added [Path Filters provided by GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-paths) by default. So it will trigger this release action only when it detects changes on the `main` branch and `installer` directory.