### PR TITLE
pkg/importer: Import manifests locally if gitURL isn't set

### DIFF
--- a/installer/cmd/render.go
+++ b/installer/cmd/render.go
@@ -205,17 +205,29 @@ func renderKubernetesObjects(cfg *config.Config) ([]string, error) {
 
 	for _, imp := range ctx.Config.Imports.Kustomize {
 		kImporter := importer.NewKustomizeImporter(imp.GitURL, imp.Path)
-		output = append(output, kImporter.Import()...)
+		imports, err := kImporter.Import()
+		if err != nil {
+			return nil, fmt.Errorf("failed to import kustomize. gitURL: %s path: %s: %v", imp.GitURL, imp.Path, err)
+		}
+		output = append(output, imports...)
 	}
 
 	for _, imp := range ctx.Config.Imports.YAML {
 		yImporter := importer.NewYAMLImporter(imp.GitURL, imp.Path)
-		output = append(output, yImporter.Import()...)
+		imports, err := yImporter.Import()
+		if err != nil {
+			return nil, fmt.Errorf("failed to import yaml. gitURL: %s path: %s: %v", imp.GitURL, imp.Path, err)
+		}
+		output = append(output, imports...)
 	}
 
 	if ctx.Config.Grafana.Install {
 		grafanaImporter := importer.NewYAMLImporter("https://github.com/gitpod-io/observability", "monitoring-satellite/manifests/grafana")
-		output = append(output, grafanaImporter.Import()...)
+		imports, err := grafanaImporter.Import()
+		if err != nil {
+			return nil, fmt.Errorf("failed to import grafana manifests: %v", err)
+		}
+		output = append(output, imports...)
 		output = append(output, "---")
 	}
 

--- a/installer/examples/full-config.yaml
+++ b/installer/examples/full-config.yaml
@@ -35,7 +35,6 @@ werft:
   installServiceMonitors: false
 imports:
   yaml:
-    - gitURL: https://github.com/gitpod-io/observability
-      path: monitoring-satellite/manifests/kube-prometheus-rules
+    - path: ../monitoring-satellite/manifests/kube-prometheus-rules
     - gitURL: https://github.com/gitpod-io/observability
       path: monitoring-satellite/manifests/probers

--- a/installer/pkg/importer/importer.go
+++ b/installer/pkg/importer/importer.go
@@ -1,7 +1,6 @@
 package importer
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/go-git/go-git/v5"
@@ -12,7 +11,7 @@ const (
 )
 
 type Importer struct {
-	GitURL string `json:"gitURL"`
+	GitURL string `json:"gitURL,omitEmpty"`
 	Path   string `json:"path"`
 }
 
@@ -23,13 +22,13 @@ func newImporter(gitURL, path string) *Importer {
 	}
 }
 
-func (i Importer) cloneRepository() {
+func (i Importer) cloneRepository() error {
 	os.RemoveAll(clonePath)
 	_, err := git.PlainClone(clonePath, false, &git.CloneOptions{
 		URL: i.GitURL,
 	})
-
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
+	return nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
After discussion on today's team sync, we noticed that we could get some velocity if we could just render manifests from local path. This PR updates the import behavior to allow empty `gitURL` and to try to import locally if such field is missing.



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #334 

