### PR TITLE
[supervisor] remove gitpod filtering to collect grpc common metrics

### DIFF
--- a/installer/pkg/components/gitpod/workspaces.go
+++ b/installer/pkg/components/gitpod/workspaces.go
@@ -44,15 +44,6 @@ func workspaceObjects() common.RenderFunc {
 							Interval:      "60s",
 							Port:          "supervisor",
 							ScrapeTimeout: "5s",
-							MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
-								{
-									Action: "keep",
-									Regex:  "gitpod_(.*)",
-									SourceLabels: []monitoringv1.LabelName{
-										"__name__",
-									},
-								},
-							},
 						},
 					},
 				},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We need to collect grpc metrics for supervisor API. It does not have gitpod prefix. See https://github.com/gitpod-io/gitpod/pull/13309

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
