### PR TITLE
Rename Self-Hosted Team in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gitpod-io/engineering-self-hosted
+* @gitpod-io/engineering-delivery-operations-experience


### PR DESCRIPTION
Renames the team handle of the Delivery and Operations Experience Team in `CODEOWNERS`.

https://github.com/orgs/gitpod-io/teams/engineering-delivery-operations-experience