### PR TITLE
Configure victoriametrics to scrape itself

### DIFF
--- a/components/victoriametrics/victoriametrics.libsonnet
+++ b/components/victoriametrics/victoriametrics.libsonnet
@@ -135,6 +135,7 @@ function(params) {
               args: [
                 '-search.maxUniqueTimeseries=3000000',
                 '-search.maxQueryDuration=60s',
+                '-selfScrapeInterval=60s',
               ],
               ports: [{
                 containerPort: $._config.port,


### PR DESCRIPTION
Following [official docs](https://docs.victoriametrics.com/?highlight=self#monitoring), adding the flag `-selfScrapeInterval` will make victoriametrics scrape metrics from itself, enabling us to build our dashboards and SLOs