### PR TITLE
Add posibility to drop metrics

### DIFF
--- a/installer/examples/full-config.yaml
+++ b/installer/examples/full-config.yaml
@@ -17,6 +17,7 @@ kubescape:
   install: true
 namespace: monitoring-satellite
 prometheus:
+  metricsToDrop: ["apiserver_request_duration_seconds_bucket", "apiserver_request_slo_duration_seconds_bucket"]
   remoteWrite:
   - password: password
     url: https://example.com

--- a/installer/pkg/components/alertmanager/servicemonitor.go
+++ b/installer/pkg/components/alertmanager/servicemonitor.go
@@ -1,6 +1,8 @@
 package alertmanager
 
 import (
+	"strings"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,10 +27,24 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 					{
 						Port:     "web",
 						Interval: "30s",
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						},
 					},
 					{
 						Port:     "reloader-web",
 						Interval: "30s",
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						},
 					},
 				},
 				Selector: metav1.LabelSelector{

--- a/installer/pkg/components/cert-manager/servicemonitor.go
+++ b/installer/pkg/components/cert-manager/servicemonitor.go
@@ -1,6 +1,8 @@
 package certmanager
 
 import (
+	"strings"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,6 +29,13 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Interval:    "30s",
 						Port:        "metrics",
 						HonorLabels: true,
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						},
 					},
 				},
 				NamespaceSelector: monitoringv1.NamespaceSelector{

--- a/installer/pkg/components/gitpod/servicemonitor.go
+++ b/installer/pkg/components/gitpod/servicemonitor.go
@@ -2,6 +2,7 @@ package gitpod
 
 import (
 	"fmt"
+	"strings"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +30,13 @@ func serviceMonitor(target string) common.RenderFunc {
 							BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 							Interval:        "30s",
 							Port:            "metrics",
+							MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+								{
+									SourceLabels: []monitoringv1.LabelName{"__name__"},
+									Regex:        strings.Join(cfg.Config.Prometheus.MetricsToDrop, "|"),
+									Action:       "drop",
+								},
+							},
 						},
 					},
 					JobLabel: "app.kubernetes.io/component",

--- a/installer/pkg/components/kubernetes/apiserver.go
+++ b/installer/pkg/components/kubernetes/apiserver.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"strings"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,6 +58,11 @@ func serviceMonitorAPIServer(ctx *common.RenderContext) ([]runtime.Object, error
 							},
 						},
 						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
 							{
 								Action:       "drop",
 								Regex:        "kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)",
@@ -120,6 +126,11 @@ func serviceMonitorAPIServer(ctx *common.RenderContext) ([]runtime.Object, error
 						},
 						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
 							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+							{
 								Action:       "drop",
 								Regex:        "container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)",
 								SourceLabels: []monitoringv1.LabelName{"__name__"},
@@ -152,6 +163,13 @@ func serviceMonitorAPIServer(ctx *common.RenderContext) ([]runtime.Object, error
 							{
 								SourceLabels: []monitoringv1.LabelName{"__metrics_path__"},
 								TargetLabel:  "metrics_path",
+							},
+						},
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
 							},
 						},
 						TLSConfig: &monitoringv1.TLSConfig{

--- a/installer/pkg/components/kubernetes/kubelet.go
+++ b/installer/pkg/components/kubernetes/kubelet.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"strings"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,6 +53,11 @@ func serviceMonitorKubelet(ctx *common.RenderContext) ([]runtime.Object, error) 
 							},
 						},
 						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
 							{
 								Action:       "drop",
 								Regex:        "kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)",

--- a/installer/pkg/components/kubestate-metrics/servicemonitor.go
+++ b/installer/pkg/components/kubestate-metrics/servicemonitor.go
@@ -1,6 +1,8 @@
 package kubestatemetrics
 
 import (
+	"strings"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -84,7 +86,13 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 								InsecureSkipVerify: true,
 							},
 						},
-						MetricRelabelConfigs: configs,
+						MetricRelabelConfigs: append(configs,
+							&monitoringv1.RelabelConfig{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						),
 						RelabelConfigs: []*monitoringv1.RelabelConfig{
 							{
 								Action: "labeldrop",

--- a/installer/pkg/components/node-exporter/servicemonitor.go
+++ b/installer/pkg/components/node-exporter/servicemonitor.go
@@ -1,6 +1,8 @@
 package nodeexporter
 
 import (
+	"strings"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,6 +32,13 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 						TLSConfig: &monitoringv1.TLSConfig{
 							SafeTLSConfig: monitoringv1.SafeTLSConfig{
 								InsecureSkipVerify: true,
+							},
+						},
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
 							},
 						},
 						RelabelConfigs: []*monitoringv1.RelabelConfig{

--- a/installer/pkg/components/otel-collector/servicemonitor.go
+++ b/installer/pkg/components/otel-collector/servicemonitor.go
@@ -1,6 +1,8 @@
 package otelcollector
 
 import (
+	"strings"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,6 +28,13 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 						Port:            "metrics",
 						Interval:        "30s",
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						},
 					},
 				},
 				NamespaceSelector: monitoringv1.NamespaceSelector{

--- a/installer/pkg/components/probers/servicemonitor.go
+++ b/installer/pkg/components/probers/servicemonitor.go
@@ -1,6 +1,8 @@
 package probers
 
 import (
+	"strings"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,6 +28,13 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 						Port:            "metrics",
 						Interval:        "60s",
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						},
 					},
 				},
 				NamespaceSelector: monitoringv1.NamespaceSelector{

--- a/installer/pkg/components/prometheus-operator/serviceMonitor.go
+++ b/installer/pkg/components/prometheus-operator/serviceMonitor.go
@@ -1,6 +1,8 @@
 package prometheusoperator
 
 import (
+	"strings"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +35,13 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 						TLSConfig: &monitoringv1.TLSConfig{
 							SafeTLSConfig: monitoringv1.SafeTLSConfig{
 								InsecureSkipVerify: true,
+							},
+						},
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
 							},
 						},
 					},

--- a/installer/pkg/components/prometheus/serviceMonitor.go
+++ b/installer/pkg/components/prometheus/serviceMonitor.go
@@ -1,6 +1,8 @@
 package prometheus
 
 import (
+	"strings"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,14 +27,35 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 					{
 						Port:     "web",
 						Interval: "30s",
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						},
 					},
 					{
 						Port:     "reloader-web",
 						Interval: "30s",
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						},
 					},
 					{
 						Port:     "cardinality",
 						Interval: "5m",
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						},
 					},
 				},
 				Selector: metav1.LabelSelector{

--- a/installer/pkg/config/config.go
+++ b/installer/pkg/config/config.go
@@ -113,6 +113,7 @@ type TeamAlertingRoute struct {
 type Prometheus struct {
 	ExternalLabels map[string]string           `json:"externalLabels,omitempty"`
 	EnableFeatures []string                    `json:"enableFeatures,omitempty"`
+	MetricsToDrop  []string                    `json:"metricsToDrop,omitempty"`
 	Ingress        *GoogleIAPBasedIngress      `json:"ingress,omitempty"`
 	Resources      corev1.ResourceRequirements `json:"resources,omitempty"`
 	RemoteWrite    []*RemoteWrite              `json:"remoteWrite,omitempty"`


### PR DESCRIPTION
Adds a single field to our config, which will configure all servicemonitors to drop unnecessary metrics.

---

This PR is the first effort after [Metric reduction analysis](https://www.notion.so/gitpod/Metric-reduction-analysis-b7d0032a30a341e5b44122aab197927a).

We'll have follow up PRs for:
* Configuring ArgoCD apps to use this new field.
* Configure Monitoring-satellite in workspace cluster's scripts
* Configure serviceMonitors that are being imported as raw YAML