### PR TITLE
fix whitespace in config yaml

### DIFF
--- a/installer/examples/default-config.yaml
+++ b/installer/examples/default-config.yaml
@@ -23,5 +23,7 @@ pyrra:
   install: false
 tracing:
   install: false
+  tempoBasicPassword: password
+  tempoBasicUser: user
 werft:
   installServiceMonitors: false

--- a/installer/pkg/components/otel-collector/configmap.go
+++ b/installer/pkg/components/otel-collector/configmap.go
@@ -82,9 +82,9 @@ func buildExportersConfig(ctx *common.RenderContext) string {
       "x-honeycomb-team": "%s"
       "x-honeycomb-dataset": "%s"
   otlp/tempo:
-  	endpoint: "otel-gateway.gitpod.io"
-	auth:
-	  authenticator: basicauth/client`,
+    endpoint: "otel-gateway.gitpod.io"
+      auth:
+        authenticator: basicauth/client`,
 		ctx.Config.Tracing.HoneycombAPIKey, ctx.Config.Tracing.HoneycombDataset)
 }
 

--- a/installer/pkg/components/otel-collector/configmap.go
+++ b/installer/pkg/components/otel-collector/configmap.go
@@ -83,8 +83,8 @@ func buildExportersConfig(ctx *common.RenderContext) string {
       "x-honeycomb-dataset": "%s"
   otlp/tempo:
     endpoint: "otel-gateway.gitpod.io"
-      auth:
-        authenticator: basicauth/client`,
+    auth:
+      authenticator: basicauth/client`,
 		ctx.Config.Tracing.HoneycombAPIKey, ctx.Config.Tracing.HoneycombDataset)
 }
 

--- a/installer/pkg/components/otel-collector/constants.go
+++ b/installer/pkg/components/otel-collector/constants.go
@@ -4,7 +4,7 @@ const (
 	Name      = "otel-collector"
 	App       = "kube-prometheus"
 	Component = "collector"
-	Version   = "0.38.0"
+	Version   = "0.66.0"
 	Namespace = "monitoring-satellite"
 	ImageURL  = "otel/opentelemetry-collector-contrib"
 )

--- a/installer/pkg/config/config.go
+++ b/installer/pkg/config/config.go
@@ -26,7 +26,9 @@ func Defaults(in interface{}) error {
 	cfg.Alerting = &Alerting{}
 
 	cfg.Tracing = &Tracing{
-		Install: false,
+		Install:            false,
+		TempoBasicUser:     "user",
+		TempoBasicPassword: "password",
 	}
 
 	cfg.Pyrra = &Pyrra{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes an issue with hard tabs in yaml

## Testing
In the `installer` dir, run `make generate-full`. The otel configmap is now correctly formatted in yaml