### PR TITLE
Otel-collector: Add configmap checksum to deployment spec

### DIFF
--- a/installer/pkg/components/otel-collector/configmap.go
+++ b/installer/pkg/components/otel-collector/configmap.go
@@ -1,6 +1,8 @@
 package otelcollector
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -13,16 +15,7 @@ import (
 const extraAttributesProcessor = "attributes"
 
 func configMap(ctx *common.RenderContext) ([]runtime.Object, error) {
-	var receiversConfig = buildReceiversConfig(ctx)
-	var processorsConfig = buildProcessorsConfig(ctx)
-	var exportersConfig = buildExportersConfig(ctx)
-	var extensionsConfig = buildExtensionsConfig(ctx)
-	var serviceConfig = buildServiceConfig(ctx)
-	var config = fmt.Sprintf(`%s
-%s
-%s
-%s
-%s`, receiversConfig, processorsConfig, exportersConfig, extensionsConfig, serviceConfig)
+	config := configMapContent(ctx)
 
 	return []runtime.Object{
 		&corev1.ConfigMap{
@@ -119,4 +112,25 @@ func buildServiceConfig(ctx *common.RenderContext) string {
 	}
 
 	return fmt.Sprintf(serviceTemplate, processors)
+}
+
+func configMapContent(ctx *common.RenderContext) string {
+	var receiversConfig = buildReceiversConfig(ctx)
+	var processorsConfig = buildProcessorsConfig(ctx)
+	var exportersConfig = buildExportersConfig(ctx)
+	var extensionsConfig = buildExtensionsConfig(ctx)
+	var serviceConfig = buildServiceConfig(ctx)
+	var config = fmt.Sprintf(`%s
+%s
+%s
+%s
+%s`, receiversConfig, processorsConfig, exportersConfig, extensionsConfig, serviceConfig)
+
+	return config
+}
+
+func configMapCheckSum(ctx *common.RenderContext) string {
+	shaBytes := sha256.Sum256([]byte(configMapContent(ctx)))
+
+	return hex.EncodeToString(shaBytes[:])
 }

--- a/installer/pkg/components/otel-collector/deployment.go
+++ b/installer/pkg/components/otel-collector/deployment.go
@@ -26,6 +26,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: common.Labels(Name, Component, App, Version),
+						Annotations: map[string]string{
+							"configmap.checksum": configMapCheckSum(ctx),
+						},
 					},
 					Spec: corev1.PodSpec{
 						ServiceAccountName: Name,


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Adds the configmap checksum to the Pod template in Otel-Collector's deployment, aiming to trigger a restart if the configmap changes.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/1084
