### PR TITLE
prometheus: Remove cardinality-analysis sidecar

### DIFF
--- a/installer/pkg/components/prometheus/prometheus.go
+++ b/installer/pkg/components/prometheus/prometheus.go
@@ -40,9 +40,6 @@ func prometheus(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			RuleSelector: &metav1.LabelSelector{},
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				Containers: []corev1.Container{
-					cardinalityExporterSideCar(),
-				},
 				Image: pointer.String(fmt.Sprintf("%s:v%s", ImageURL, Version)),
 				PodMetadata: &monitoringv1.EmbeddedObjectMetadata{
 					Labels: common.Labels(Name, Component, App, Version),
@@ -115,17 +112,4 @@ func remoteWriteSpecs(ctx *common.RenderContext) []monitoringv1.RemoteWriteSpec 
 	}
 
 	return specs
-}
-
-func cardinalityExporterSideCar() corev1.Container {
-	return corev1.Container{
-		Name:  "cardinality-exporter",
-		Image: "ghcr.io/arthursens/cardinality-exporter:main",
-		Ports: []corev1.ContainerPort{
-			{
-				Name:          "cardinality",
-				ContainerPort: 9091,
-			},
-		},
-	}
 }

--- a/installer/pkg/components/prometheus/service.go
+++ b/installer/pkg/components/prometheus/service.go
@@ -33,11 +33,6 @@ func service(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Port:       8080,
 						TargetPort: intstr.FromString("reloader-web"),
 					},
-					{
-						Name:       "cardinality",
-						Port:       9091,
-						TargetPort: intstr.FromString("cardinality"),
-					},
 				},
 				Selector: map[string]string{
 					"app.kubernetes.io/name": "prometheus",

--- a/installer/pkg/components/prometheus/serviceMonitor.go
+++ b/installer/pkg/components/prometheus/serviceMonitor.go
@@ -40,17 +40,6 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 							},
 						},
 					},
-					{
-						Port:     "cardinality",
-						Interval: "5m",
-						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__"},
-								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
-								Action:       "drop",
-							},
-						},
-					},
 				},
 				Selector: metav1.LabelSelector{
 					MatchLabels: common.Labels(Name, Component, App, Version),

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -142,7 +142,7 @@ func TestQueryPrometheus(t *testing.T) {
 			expectN: 2,
 		}, {
 			query:   `up{job="prometheus-k8s"} == 1`,
-			expectN: 3,
+			expectN: 2,
 		}, {
 			query:   `up{job="prometheus-operator"} == 1`,
 			expectN: 1,


### PR DESCRIPTION
Fixes https://github.com/gitpod-io/observability/issues/369

----

[Mimirtool has proven to be a much more effective tool to analyze metrics cardinality](https://www.notion.so/gitpod/Metric-reduction-analysis-b7d0032a30a341e5b44122aab197927a), making the sidecar unnecessary.