### PR TITLE
Revert "Revert "Add posibility to drop metrics""

### DIFF
--- a/installer/examples/full-config.yaml
+++ b/installer/examples/full-config.yaml
@@ -17,6 +17,7 @@ kubescape:
   install: true
 namespace: monitoring-satellite
 prometheus:
+  metricsToDrop: ["apiserver_request_duration_seconds_bucket", "apiserver_request_slo_duration_seconds_bucket"]
   remoteWrite:
   - password: password
     url: https://example.com

--- a/installer/pkg/common/common.go
+++ b/installer/pkg/common/common.go
@@ -1,6 +1,9 @@
 package common
 
 import (
+	"strings"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -32,3 +35,16 @@ var (
 		Kind:       "NetworkPolicy",
 	}
 )
+
+func DropMetricsRelabeling(ctx *RenderContext) []*monitoringv1.RelabelConfig {
+	if ctx.Config.Prometheus.MetricsToDrop != nil {
+		return []*monitoringv1.RelabelConfig{
+			{
+				SourceLabels: []monitoringv1.LabelName{"__name__"},
+				Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+				Action:       "drop",
+			},
+		}
+	}
+	return nil
+}

--- a/installer/pkg/components/alertmanager/servicemonitor.go
+++ b/installer/pkg/components/alertmanager/servicemonitor.go
@@ -1,6 +1,8 @@
 package alertmanager
 
 import (
+	"strings"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,10 +27,24 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 					{
 						Port:     "web",
 						Interval: "30s",
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						},
 					},
 					{
 						Port:     "reloader-web",
 						Interval: "30s",
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						},
 					},
 				},
 				Selector: metav1.LabelSelector{

--- a/installer/pkg/components/alertmanager/servicemonitor.go
+++ b/installer/pkg/components/alertmanager/servicemonitor.go
@@ -1,8 +1,6 @@
 package alertmanager
 
 import (
-	"strings"
-
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,26 +23,14 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Spec: monitoringv1.ServiceMonitorSpec{
 				Endpoints: []monitoringv1.Endpoint{
 					{
-						Port:     "web",
-						Interval: "30s",
-						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__"},
-								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
-								Action:       "drop",
-							},
-						},
+						Port:                 "web",
+						Interval:             "30s",
+						MetricRelabelConfigs: common.DropMetricsRelabeling(ctx),
 					},
 					{
-						Port:     "reloader-web",
-						Interval: "30s",
-						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__"},
-								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
-								Action:       "drop",
-							},
-						},
+						Port:                 "reloader-web",
+						Interval:             "30s",
+						MetricRelabelConfigs: common.DropMetricsRelabeling(ctx),
 					},
 				},
 				Selector: metav1.LabelSelector{

--- a/installer/pkg/components/cert-manager/servicemonitor.go
+++ b/installer/pkg/components/cert-manager/servicemonitor.go
@@ -1,6 +1,8 @@
 package certmanager
 
 import (
+	"strings"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,6 +29,13 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Interval:    "30s",
 						Port:        "metrics",
 						HonorLabels: true,
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						},
 					},
 				},
 				NamespaceSelector: monitoringv1.NamespaceSelector{

--- a/installer/pkg/components/cert-manager/servicemonitor.go
+++ b/installer/pkg/components/cert-manager/servicemonitor.go
@@ -1,8 +1,6 @@
 package certmanager
 
 import (
-	"strings"
-
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,16 +24,10 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 				JobLabel: "app.kubernetes.io/name",
 				Endpoints: []monitoringv1.Endpoint{
 					{
-						Interval:    "30s",
-						Port:        "metrics",
-						HonorLabels: true,
-						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__"},
-								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
-								Action:       "drop",
-							},
-						},
+						Interval:             "30s",
+						Port:                 "metrics",
+						HonorLabels:          true,
+						MetricRelabelConfigs: common.DropMetricsRelabeling(ctx),
 					},
 				},
 				NamespaceSelector: monitoringv1.NamespaceSelector{

--- a/installer/pkg/components/gitpod/servicemonitor.go
+++ b/installer/pkg/components/gitpod/servicemonitor.go
@@ -2,7 +2,6 @@ package gitpod
 
 import (
 	"fmt"
-	"strings"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,16 +26,10 @@ func serviceMonitor(target string) common.RenderFunc {
 				Spec: monitoringv1.ServiceMonitorSpec{
 					Endpoints: []monitoringv1.Endpoint{
 						{
-							BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
-							Interval:        "30s",
-							Port:            "metrics",
-							MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
-								{
-									SourceLabels: []monitoringv1.LabelName{"__name__"},
-									Regex:        strings.Join(cfg.Config.Prometheus.MetricsToDrop, "|"),
-									Action:       "drop",
-								},
-							},
+							BearerTokenFile:      "/var/run/secrets/kubernetes.io/serviceaccount/token",
+							Interval:             "30s",
+							Port:                 "metrics",
+							MetricRelabelConfigs: common.DropMetricsRelabeling(cfg),
 						},
 					},
 					JobLabel: "app.kubernetes.io/component",

--- a/installer/pkg/components/gitpod/servicemonitor.go
+++ b/installer/pkg/components/gitpod/servicemonitor.go
@@ -2,6 +2,7 @@ package gitpod
 
 import (
 	"fmt"
+	"strings"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +30,13 @@ func serviceMonitor(target string) common.RenderFunc {
 							BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 							Interval:        "30s",
 							Port:            "metrics",
+							MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+								{
+									SourceLabels: []monitoringv1.LabelName{"__name__"},
+									Regex:        strings.Join(cfg.Config.Prometheus.MetricsToDrop, "|"),
+									Action:       "drop",
+								},
+							},
 						},
 					},
 					JobLabel: "app.kubernetes.io/component",

--- a/installer/pkg/components/kubernetes/apiserver.go
+++ b/installer/pkg/components/kubernetes/apiserver.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"fmt"
-	"strings"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,12 +56,7 @@ func serviceMonitorAPIServer(ctx *common.RenderContext) ([]runtime.Object, error
 								TargetLabel:  "metrics_path",
 							},
 						},
-						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__"},
-								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
-								Action:       "drop",
-							},
+						MetricRelabelConfigs: append([]*monitoringv1.RelabelConfig{
 							{
 								Action:       "drop",
 								Regex:        "kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)",
@@ -103,7 +97,7 @@ func serviceMonitorAPIServer(ctx *common.RenderContext) ([]runtime.Object, error
 								Regex:        "(admission_quota_controller_adds|admission_quota_controller_depth|admission_quota_controller_longest_running_processor_microseconds|admission_quota_controller_queue_latency|admission_quota_controller_unfinished_work_seconds|admission_quota_controller_work_duration|APIServiceOpenAPIAggregationControllerQueue1_adds|APIServiceOpenAPIAggregationControllerQueue1_depth|APIServiceOpenAPIAggregationControllerQueue1_longest_running_processor_microseconds|APIServiceOpenAPIAggregationControllerQueue1_queue_latency|APIServiceOpenAPIAggregationControllerQueue1_retries|APIServiceOpenAPIAggregationControllerQueue1_unfinished_work_seconds|APIServiceOpenAPIAggregationControllerQueue1_work_duration|APIServiceRegistrationController_adds|APIServiceRegistrationController_depth|APIServiceRegistrationController_longest_running_processor_microseconds|APIServiceRegistrationController_queue_latency|APIServiceRegistrationController_retries|APIServiceRegistrationController_unfinished_work_seconds|APIServiceRegistrationController_work_duration|autoregister_adds|autoregister_depth|autoregister_longest_running_processor_microseconds|autoregister_queue_latency|autoregister_retries|autoregister_unfinished_work_seconds|autoregister_work_duration|AvailableConditionController_adds|AvailableConditionController_depth|AvailableConditionController_longest_running_processor_microseconds|AvailableConditionController_queue_latency|AvailableConditionController_retries|AvailableConditionController_unfinished_work_seconds|AvailableConditionController_work_duration|crd_autoregistration_controller_adds|crd_autoregistration_controller_depth|crd_autoregistration_controller_longest_running_processor_microseconds|crd_autoregistration_controller_queue_latency|crd_autoregistration_controller_retries|crd_autoregistration_controller_unfinished_work_seconds|crd_autoregistration_controller_work_duration|crdEstablishing_adds|crdEstablishing_depth|crdEstablishing_longest_running_processor_microseconds|crdEstablishing_queue_latency|crdEstablishing_retries|crdEstablishing_unfinished_work_seconds|crdEstablishing_work_duration|crd_finalizer_adds|crd_finalizer_depth|crd_finalizer_longest_running_processor_microseconds|crd_finalizer_queue_latency|crd_finalizer_retries|crd_finalizer_unfinished_work_seconds|crd_finalizer_work_duration|crd_naming_condition_controller_adds|crd_naming_condition_controller_depth|crd_naming_condition_controller_longest_running_processor_microseconds|crd_naming_condition_controller_queue_latency|crd_naming_condition_controller_retries|crd_naming_condition_controller_unfinished_work_seconds|crd_naming_condition_controller_work_duration|crd_openapi_controller_adds|crd_openapi_controller_depth|crd_openapi_controller_longest_running_processor_microseconds|crd_openapi_controller_queue_latency|crd_openapi_controller_retries|crd_openapi_controller_unfinished_work_seconds|crd_openapi_controller_work_duration|DiscoveryController_adds|DiscoveryController_depth|DiscoveryController_longest_running_processor_microseconds|DiscoveryController_queue_latency|DiscoveryController_retries|DiscoveryController_unfinished_work_seconds|DiscoveryController_work_duration|kubeproxy_sync_proxy_rules_latency_microseconds|non_structural_schema_condition_controller_adds|non_structural_schema_condition_controller_depth|non_structural_schema_condition_controller_longest_running_processor_microseconds|non_structural_schema_condition_controller_queue_latency|non_structural_schema_condition_controller_retries|non_structural_schema_condition_controller_unfinished_work_seconds|non_structural_schema_condition_controller_work_duration|rest_client_request_latency_seconds|storage_operation_errors_total|storage_operation_status_count)",
 								SourceLabels: []monitoringv1.LabelName{"__name__"},
 							},
-						},
+						}, common.DropMetricsRelabeling(ctx)...),
 					},
 					{
 						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
@@ -124,12 +118,7 @@ func serviceMonitorAPIServer(ctx *common.RenderContext) ([]runtime.Object, error
 								TargetLabel:  "metrics_path",
 							},
 						},
-						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__"},
-								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
-								Action:       "drop",
-							},
+						MetricRelabelConfigs: append([]*monitoringv1.RelabelConfig{
 							{
 								Action:       "drop",
 								Regex:        "container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)",
@@ -150,7 +139,7 @@ func serviceMonitorAPIServer(ctx *common.RenderContext) ([]runtime.Object, error
 								Regex:        "container_(memory_failures_total|fs_reads_total|cpu_user_seconds_total|memory_failcnt|cpu_system_seconds_total|memory_max_usage_bytes|memory_swap|processes|memory_cache|memory_mapped_file|memory_usage_bytes|sockets|spec_cpu_period|spec_memory_limit_bytes|file_descriptors|spec_memory_reservation_limit_bytes|last_seen|spec_cpu_shares|spec_memory_swap_limit_bytes|threads_max|start_time_seconds|threads|ulimits_soft|cpu_cfs_periods_total|cpu_cfs_throttled_periods_total|spec_cpu_quota|blkio_device_usage_total)",
 								SourceLabels: []monitoringv1.LabelName{"__name__"},
 							},
-						},
+						}, common.DropMetricsRelabeling(ctx)...),
 					},
 					{
 						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
@@ -165,13 +154,7 @@ func serviceMonitorAPIServer(ctx *common.RenderContext) ([]runtime.Object, error
 								TargetLabel:  "metrics_path",
 							},
 						},
-						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__"},
-								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
-								Action:       "drop",
-							},
-						},
+						MetricRelabelConfigs: common.DropMetricsRelabeling(ctx),
 						TLSConfig: &monitoringv1.TLSConfig{
 							SafeTLSConfig: monitoringv1.SafeTLSConfig{
 								InsecureSkipVerify: true,

--- a/installer/pkg/components/kubernetes/apiserver.go
+++ b/installer/pkg/components/kubernetes/apiserver.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"strings"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,6 +58,11 @@ func serviceMonitorAPIServer(ctx *common.RenderContext) ([]runtime.Object, error
 							},
 						},
 						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
 							{
 								Action:       "drop",
 								Regex:        "kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)",
@@ -120,6 +126,11 @@ func serviceMonitorAPIServer(ctx *common.RenderContext) ([]runtime.Object, error
 						},
 						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
 							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+							{
 								Action:       "drop",
 								Regex:        "container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)",
 								SourceLabels: []monitoringv1.LabelName{"__name__"},
@@ -152,6 +163,13 @@ func serviceMonitorAPIServer(ctx *common.RenderContext) ([]runtime.Object, error
 							{
 								SourceLabels: []monitoringv1.LabelName{"__metrics_path__"},
 								TargetLabel:  "metrics_path",
+							},
+						},
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
 							},
 						},
 						TLSConfig: &monitoringv1.TLSConfig{

--- a/installer/pkg/components/kubernetes/kubelet.go
+++ b/installer/pkg/components/kubernetes/kubelet.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"fmt"
-	"strings"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,12 +51,7 @@ func serviceMonitorKubelet(ctx *common.RenderContext) ([]runtime.Object, error) 
 								ServerName: "kubernetes",
 							},
 						},
-						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__"},
-								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
-								Action:       "drop",
-							},
+						MetricRelabelConfigs: append([]*monitoringv1.RelabelConfig{
 							{
 								Action:       "drop",
 								Regex:        "kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)",
@@ -118,7 +112,7 @@ func serviceMonitorKubelet(ctx *common.RenderContext) ([]runtime.Object, error) 
 								Regex:        "apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)",
 								SourceLabels: []monitoringv1.LabelName{"__name__", "le"},
 							},
-						},
+						}, common.DropMetricsRelabeling(ctx)...),
 					},
 				},
 			},

--- a/installer/pkg/components/kubernetes/kubelet.go
+++ b/installer/pkg/components/kubernetes/kubelet.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"strings"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,6 +53,11 @@ func serviceMonitorKubelet(ctx *common.RenderContext) ([]runtime.Object, error) 
 							},
 						},
 						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
 							{
 								Action:       "drop",
 								Regex:        "kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)",

--- a/installer/pkg/components/kubestate-metrics/servicemonitor.go
+++ b/installer/pkg/components/kubestate-metrics/servicemonitor.go
@@ -1,8 +1,6 @@
 package kubestatemetrics
 
 import (
-	"strings"
-
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -86,13 +84,7 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 								InsecureSkipVerify: true,
 							},
 						},
-						MetricRelabelConfigs: append(configs,
-							&monitoringv1.RelabelConfig{
-								SourceLabels: []monitoringv1.LabelName{"__name__"},
-								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
-								Action:       "drop",
-							},
-						),
+						MetricRelabelConfigs: append(configs, common.DropMetricsRelabeling(ctx)...),
 						RelabelConfigs: []*monitoringv1.RelabelConfig{
 							{
 								Action: "labeldrop",

--- a/installer/pkg/components/kubestate-metrics/servicemonitor.go
+++ b/installer/pkg/components/kubestate-metrics/servicemonitor.go
@@ -1,6 +1,8 @@
 package kubestatemetrics
 
 import (
+	"strings"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -84,7 +86,13 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 								InsecureSkipVerify: true,
 							},
 						},
-						MetricRelabelConfigs: configs,
+						MetricRelabelConfigs: append(configs,
+							&monitoringv1.RelabelConfig{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						),
 						RelabelConfigs: []*monitoringv1.RelabelConfig{
 							{
 								Action: "labeldrop",

--- a/installer/pkg/components/node-exporter/servicemonitor.go
+++ b/installer/pkg/components/node-exporter/servicemonitor.go
@@ -1,8 +1,6 @@
 package nodeexporter
 
 import (
-	"strings"
-
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,13 +32,7 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 								InsecureSkipVerify: true,
 							},
 						},
-						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__"},
-								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
-								Action:       "drop",
-							},
-						},
+						MetricRelabelConfigs: common.DropMetricsRelabeling(ctx),
 						RelabelConfigs: []*monitoringv1.RelabelConfig{
 							{
 								Action:      "replace",

--- a/installer/pkg/components/node-exporter/servicemonitor.go
+++ b/installer/pkg/components/node-exporter/servicemonitor.go
@@ -1,6 +1,8 @@
 package nodeexporter
 
 import (
+	"strings"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,6 +32,13 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 						TLSConfig: &monitoringv1.TLSConfig{
 							SafeTLSConfig: monitoringv1.SafeTLSConfig{
 								InsecureSkipVerify: true,
+							},
+						},
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
 							},
 						},
 						RelabelConfigs: []*monitoringv1.RelabelConfig{

--- a/installer/pkg/components/otel-collector/servicemonitor.go
+++ b/installer/pkg/components/otel-collector/servicemonitor.go
@@ -1,8 +1,6 @@
 package otelcollector
 
 import (
-	"strings"
-
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,16 +23,10 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Spec: monitoringv1.ServiceMonitorSpec{
 				Endpoints: []monitoringv1.Endpoint{
 					{
-						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
-						Port:            "metrics",
-						Interval:        "30s",
-						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__"},
-								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
-								Action:       "drop",
-							},
-						},
+						BearerTokenFile:      "/var/run/secrets/kubernetes.io/serviceaccount/token",
+						Port:                 "metrics",
+						Interval:             "30s",
+						MetricRelabelConfigs: common.DropMetricsRelabeling(ctx),
 					},
 				},
 				NamespaceSelector: monitoringv1.NamespaceSelector{

--- a/installer/pkg/components/otel-collector/servicemonitor.go
+++ b/installer/pkg/components/otel-collector/servicemonitor.go
@@ -1,6 +1,8 @@
 package otelcollector
 
 import (
+	"strings"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,6 +28,13 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 						Port:            "metrics",
 						Interval:        "30s",
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						},
 					},
 				},
 				NamespaceSelector: monitoringv1.NamespaceSelector{

--- a/installer/pkg/components/probers/servicemonitor.go
+++ b/installer/pkg/components/probers/servicemonitor.go
@@ -1,6 +1,8 @@
 package probers
 
 import (
+	"strings"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,6 +28,13 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 						Port:            "metrics",
 						Interval:        "60s",
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						},
 					},
 				},
 				NamespaceSelector: monitoringv1.NamespaceSelector{

--- a/installer/pkg/components/probers/servicemonitor.go
+++ b/installer/pkg/components/probers/servicemonitor.go
@@ -1,8 +1,6 @@
 package probers
 
 import (
-	"strings"
-
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,16 +23,10 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Spec: monitoringv1.ServiceMonitorSpec{
 				Endpoints: []monitoringv1.Endpoint{
 					{
-						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
-						Port:            "metrics",
-						Interval:        "60s",
-						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__"},
-								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
-								Action:       "drop",
-							},
-						},
+						BearerTokenFile:      "/var/run/secrets/kubernetes.io/serviceaccount/token",
+						Port:                 "metrics",
+						Interval:             "60s",
+						MetricRelabelConfigs: common.DropMetricsRelabeling(ctx),
 					},
 				},
 				NamespaceSelector: monitoringv1.NamespaceSelector{

--- a/installer/pkg/components/prometheus-operator/serviceMonitor.go
+++ b/installer/pkg/components/prometheus-operator/serviceMonitor.go
@@ -1,8 +1,6 @@
 package prometheusoperator
 
 import (
-	"strings"
-
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,13 +35,7 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 								InsecureSkipVerify: true,
 							},
 						},
-						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__"},
-								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
-								Action:       "drop",
-							},
-						},
+						MetricRelabelConfigs: common.DropMetricsRelabeling(ctx),
 					},
 				},
 			},

--- a/installer/pkg/components/prometheus-operator/serviceMonitor.go
+++ b/installer/pkg/components/prometheus-operator/serviceMonitor.go
@@ -1,6 +1,8 @@
 package prometheusoperator
 
 import (
+	"strings"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +35,13 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 						TLSConfig: &monitoringv1.TLSConfig{
 							SafeTLSConfig: monitoringv1.SafeTLSConfig{
 								InsecureSkipVerify: true,
+							},
+						},
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
 							},
 						},
 					},

--- a/installer/pkg/components/prometheus/serviceMonitor.go
+++ b/installer/pkg/components/prometheus/serviceMonitor.go
@@ -25,15 +25,9 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Spec: monitoringv1.ServiceMonitorSpec{
 				Endpoints: []monitoringv1.Endpoint{
 					{
-						Port:     "web",
-						Interval: "30s",
-						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
-							{
-								SourceLabels: []monitoringv1.LabelName{"__name__"},
-								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
-								Action:       "drop",
-							},
-						},
+						Port:                 "web",
+						Interval:             "30s",
+						MetricRelabelConfigs: common.DropMetricsRelabeling(ctx),
 					},
 					{
 						Port:     "reloader-web",

--- a/installer/pkg/components/prometheus/serviceMonitor.go
+++ b/installer/pkg/components/prometheus/serviceMonitor.go
@@ -1,6 +1,8 @@
 package prometheus
 
 import (
+	"strings"
+
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,14 +27,35 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 					{
 						Port:     "web",
 						Interval: "30s",
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						},
 					},
 					{
 						Port:     "reloader-web",
 						Interval: "30s",
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						},
 					},
 					{
 						Port:     "cardinality",
 						Interval: "5m",
+						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
+							{
+								SourceLabels: []monitoringv1.LabelName{"__name__"},
+								Regex:        strings.Join(ctx.Config.Prometheus.MetricsToDrop, "|"),
+								Action:       "drop",
+							},
+						},
 					},
 				},
 				Selector: metav1.LabelSelector{

--- a/installer/pkg/config/config.go
+++ b/installer/pkg/config/config.go
@@ -117,6 +117,7 @@ type TeamAlertingRoute struct {
 type Prometheus struct {
 	ExternalLabels map[string]string           `json:"externalLabels,omitempty"`
 	EnableFeatures []string                    `json:"enableFeatures,omitempty"`
+	MetricsToDrop  []string                    `json:"metricsToDrop,omitempty"`
 	Ingress        *GoogleIAPBasedIngress      `json:"ingress,omitempty"`
 	Resources      corev1.ResourceRequirements `json:"resources,omitempty"`
 	RemoteWrite    []*RemoteWrite              `json:"remoteWrite,omitempty"`


### PR DESCRIPTION
Reverts gitpod-io/observability#388

---

But this time I've also added an extra commit that checks if the field `metricsToDrop` was set. Without this conditional, we'd drop every metric if the field isn't set.