### PR TITLE
Increase scrape interval to decrease datapoints per minute

### DIFF
--- a/installer/pkg/components/alertmanager/servicemonitor.go
+++ b/installer/pkg/components/alertmanager/servicemonitor.go
@@ -24,12 +24,12 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Endpoints: []monitoringv1.Endpoint{
 					{
 						Port:                 "web",
-						Interval:             "30s",
+						Interval:             "60s",
 						MetricRelabelConfigs: common.DropMetricsRelabeling(ctx),
 					},
 					{
 						Port:                 "reloader-web",
-						Interval:             "30s",
+						Interval:             "60s",
 						MetricRelabelConfigs: common.DropMetricsRelabeling(ctx),
 					},
 				},

--- a/installer/pkg/components/cert-manager/servicemonitor.go
+++ b/installer/pkg/components/cert-manager/servicemonitor.go
@@ -24,7 +24,7 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 				JobLabel: "app.kubernetes.io/name",
 				Endpoints: []monitoringv1.Endpoint{
 					{
-						Interval:             "30s",
+						Interval:             "60s",
 						Port:                 "metrics",
 						HonorLabels:          true,
 						MetricRelabelConfigs: common.DropMetricsRelabeling(ctx),

--- a/installer/pkg/components/gitpod/messagebus.go
+++ b/installer/pkg/components/gitpod/messagebus.go
@@ -86,7 +86,7 @@ func messagebusObjects() common.RenderFunc {
 					Endpoints: []monitoringv1.Endpoint{
 						{
 							BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
-							Interval:        "30s",
+							Interval:        "60s",
 							Port:            "metrics",
 						},
 					},

--- a/installer/pkg/components/gitpod/proxycaddy.go
+++ b/installer/pkg/components/gitpod/proxycaddy.go
@@ -37,7 +37,7 @@ func proxyCaddyObjects() common.RenderFunc {
 					Endpoints: []monitoringv1.Endpoint{
 						{
 							BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
-							Interval:        "30s",
+							Interval:        "60s",
 							Port:            "metrics",
 						},
 					},

--- a/installer/pkg/components/gitpod/servicemonitor.go
+++ b/installer/pkg/components/gitpod/servicemonitor.go
@@ -27,7 +27,7 @@ func serviceMonitor(target string) common.RenderFunc {
 					Endpoints: []monitoringv1.Endpoint{
 						{
 							BearerTokenFile:      "/var/run/secrets/kubernetes.io/serviceaccount/token",
-							Interval:             "30s",
+							Interval:             "60s",
 							Port:                 "metrics",
 							MetricRelabelConfigs: common.DropMetricsRelabeling(cfg),
 						},

--- a/installer/pkg/components/kubernetes/apiserver.go
+++ b/installer/pkg/components/kubernetes/apiserver.go
@@ -43,7 +43,7 @@ func serviceMonitorAPIServer(ctx *common.RenderContext) ([]runtime.Object, error
 						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 						HonorLabels:     true,
 						Port:            "https-metrics",
-						Interval:        "30s",
+						Interval:        "60s",
 						Scheme:          "https",
 						TLSConfig: &monitoringv1.TLSConfig{
 							SafeTLSConfig: monitoringv1.SafeTLSConfig{
@@ -103,7 +103,7 @@ func serviceMonitorAPIServer(ctx *common.RenderContext) ([]runtime.Object, error
 						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 						HonorLabels:     true,
 						HonorTimestamps: common.ToPointer(false),
-						Interval:        "30s",
+						Interval:        "60s",
 						Path:            "/metrics/cadvisor",
 						Port:            "https-metrics",
 						Scheme:          "https",
@@ -144,7 +144,7 @@ func serviceMonitorAPIServer(ctx *common.RenderContext) ([]runtime.Object, error
 					{
 						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 						HonorLabels:     true,
-						Interval:        "30s",
+						Interval:        "60s",
 						Port:            "https-metrics",
 						Path:            "/metrics/probes",
 						Scheme:          "https",

--- a/installer/pkg/components/kubernetes/kubelet.go
+++ b/installer/pkg/components/kubernetes/kubelet.go
@@ -43,7 +43,7 @@ func serviceMonitorKubelet(ctx *common.RenderContext) ([]runtime.Object, error) 
 					{
 						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 						Port:            "https",
-						Interval:        "30s",
+						Interval:        "60s",
 						Scheme:          "https",
 						TLSConfig: &monitoringv1.TLSConfig{
 							CAFile: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",

--- a/installer/pkg/components/kubestate-metrics/servicemonitor.go
+++ b/installer/pkg/components/kubestate-metrics/servicemonitor.go
@@ -75,7 +75,7 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 					{
 						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 						Port:            "https-main",
-						Interval:        "30s",
+						Interval:        "60s",
 						ScrapeTimeout:   "30s",
 						Scheme:          "https",
 						HonorLabels:     true,
@@ -95,7 +95,7 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 					{
 						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 						Port:            "https-self",
-						Interval:        "30s",
+						Interval:        "60s",
 						Scheme:          "https",
 						TLSConfig: &monitoringv1.TLSConfig{
 							SafeTLSConfig: monitoringv1.SafeTLSConfig{

--- a/installer/pkg/components/node-exporter/servicemonitor.go
+++ b/installer/pkg/components/node-exporter/servicemonitor.go
@@ -25,7 +25,7 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 					{
 						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 						Port:            "https",
-						Interval:        "15s",
+						Interval:        "60s",
 						Scheme:          "https",
 						TLSConfig: &monitoringv1.TLSConfig{
 							SafeTLSConfig: monitoringv1.SafeTLSConfig{

--- a/installer/pkg/components/otel-collector/servicemonitor.go
+++ b/installer/pkg/components/otel-collector/servicemonitor.go
@@ -25,7 +25,7 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 					{
 						BearerTokenFile:      "/var/run/secrets/kubernetes.io/serviceaccount/token",
 						Port:                 "metrics",
-						Interval:             "30s",
+						Interval:             "60s",
 						MetricRelabelConfigs: common.DropMetricsRelabeling(ctx),
 					},
 				},

--- a/installer/pkg/components/prometheus-operator/serviceMonitor.go
+++ b/installer/pkg/components/prometheus-operator/serviceMonitor.go
@@ -28,6 +28,7 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 					{
 						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 						HonorLabels:     true,
+						Interval:        "60s",
 						Port:            "https",
 						Scheme:          "https",
 						TLSConfig: &monitoringv1.TLSConfig{

--- a/installer/pkg/components/prometheus/serviceMonitor.go
+++ b/installer/pkg/components/prometheus/serviceMonitor.go
@@ -26,12 +26,12 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Endpoints: []monitoringv1.Endpoint{
 					{
 						Port:                 "web",
-						Interval:             "30s",
+						Interval:             "60s",
 						MetricRelabelConfigs: common.DropMetricsRelabeling(ctx),
 					},
 					{
 						Port:     "reloader-web",
-						Interval: "30s",
+						Interval: "60s",
 						MetricRelabelConfigs: []*monitoringv1.RelabelConfig{
 							{
 								SourceLabels: []monitoringv1.LabelName{"__name__"},

--- a/installer/pkg/components/werft/servicemonitor.go
+++ b/installer/pkg/components/werft/servicemonitor.go
@@ -24,7 +24,7 @@ func serviceMonitor(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Endpoints: []monitoringv1.Endpoint{
 					{
 						BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
-						Interval:        "30s",
+						Interval:        "60s",
 						Port:            "metrics",
 					},
 				},


### PR DESCRIPTION
Following [the RFC](https://www.notion.so/gitpod/Monitoring-central-Migration-to-Grafana-Cloud-6c29eb19a8c445aa84d680ba1c68bc66#febbbbc524a14614b7cd9c45e1af3bdc), we can decrease metric costs by reducing the frequency that we scrape metrics endpoints.

This PR updates all our ServiceMonitors to 60s.