### PR TITLE
Pin OS for release pipeline to avoid compiling inconsistently

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
We're currently gettig the error `/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found` when executing the binary released by our pipeline.

Missing OS libs can be a good indicator that the binary is being compiled in a different system than the one it is being executed. Looking at [Github doc](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners)s, I've found out the `ubuntu-latest` is currently being used by Ubuntu 20 and Ubuntu 22. Our workspaces however are still using ubuntu 20 as a base image.

This PR is pinning the OS of our release pipeline to the same one we use in our workspaces.

---

Fixes #403 