### PR TITLE
Configure metrics scraping for `slow-server`

### DIFF
--- a/installer/pkg/components/gitpod/constants.go
+++ b/installer/pkg/components/gitpod/constants.go
@@ -26,6 +26,7 @@ var (
 		"public-api-server",
 		"registry-facade",
 		"server",
+		"slow-server",
 		"usage",
 		"ws-daemon",
 		"ws-manager-bridge",


### PR DESCRIPTION
## Description

Configure metrics scraping for `slow-server` - a re-do of https://github.com/gitpod-io/observability/pull/408 which tried to add the same thing in the wrong place.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15297

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
