### PR TITLE
Increase resource limits of kube-rbac-proxy for node-exporter

### DIFF
--- a/installer/pkg/components/node-exporter/daemonset.go
+++ b/installer/pkg/components/node-exporter/daemonset.go
@@ -148,7 +148,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 								},
 								Resources: v1.ResourceRequirements{
 									Limits: v1.ResourceList{
-										v1.ResourceCPU:    resource.MustParse("20m"),
+										v1.ResourceCPU:    resource.MustParse("60m"),
 										v1.ResourceMemory: resource.MustParse("40Mi"),
 									},
 									Requests: v1.ResourceList{


### PR DESCRIPTION
When investigating https://github.com/gitpod-io/observability/issues/376, @iQQBot noticed that kube-rbac-proxy is constantly working on its limits.

Since the problem we're seeing is bad TLS termination, it could be that kube-rbac-proxy is struggling to process prometheus requests.

This PR increases the limit a little bit, giving kube-rbac-proxy some extra room to breath