### PR TITLE
Update node-exporter to 1.5.0

### DIFF
--- a/installer/pkg/components/node-exporter/constants.go
+++ b/installer/pkg/components/node-exporter/constants.go
@@ -3,7 +3,7 @@ package nodeexporter
 const (
 	Name      = "node-exporter"
 	App       = "kube-prometheus"
-	Version   = "1.3.1"
+	Version   = "1.5.0"
 	Namespace = "monitoring-satellite"
 	ImageURL  = "quay.io/prometheus/node-exporter"
 	Component = "exporter"


### PR DESCRIPTION
[Version 1.5.0](https://github.com/prometheus/node_exporter/releases/tag/v1.5.0) came with a potential fix for scraping failures on node-exporters running on servers that have a buggy kernel.

It can be a potential fix for https://github.com/gitpod-io/observability/issues/376.