### PR TITLE
Remove network policy for ws-daemon

### DIFF
--- a/installer/pkg/components/gitpod/networkpolicy.go
+++ b/installer/pkg/components/gitpod/networkpolicy.go
@@ -12,6 +12,10 @@ import (
 
 func networkPolicy(target string) common.RenderFunc {
 	return func(cfg *common.RenderContext) ([]runtime.Object, error) {
+		if target == "ws-daemon" {
+			return []runtime.Object{}, nil
+		}
+
 		return []runtime.Object{
 			&networkv1.NetworkPolicy{
 				TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
## Description

The network policy for ws-daemon is being removed https://github.com/gitpod-io/gitpod/pull/16518 and the monitoring one is avoiding connections to the component
