### PR TITLE
Support IDE-metrics service metrics and api metrics

### DIFF
--- a/installer/pkg/components/gitpod/constants.go
+++ b/installer/pkg/components/gitpod/constants.go
@@ -19,7 +19,6 @@ var (
 		"blobserve",
 		"containerd-metrics",
 		"content-service",
-		"ide-metrics",
 		"ide-service",
 		"image-builder-mk3",
 		"node-labeler",

--- a/installer/pkg/components/gitpod/idemetrics.go
+++ b/installer/pkg/components/gitpod/idemetrics.go
@@ -1,0 +1,72 @@
+package gitpod
+
+import (
+	"fmt"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gitpod-io/observability/installer/pkg/common"
+)
+
+// ideMetricsObjects cannot be generated like other components because it has 2 endpoints
+func ideMetricsObjects() common.RenderFunc {
+	return func(cfg *common.RenderContext) ([]runtime.Object, error) {
+		target := "ide-metrics"
+		var res []runtime.Object
+
+		obj, err := networkPolicy(target)(cfg)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, obj...)
+
+		obj, err = service(target)(cfg)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, obj...)
+
+		res = append(res, &monitoringv1.ServiceMonitor{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "monitoring.coreos.com/v1",
+				Kind:       "ServiceMonitor",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%s", App, target),
+				Namespace: Namespace,
+				Labels:    labels(target),
+				Annotations: map[string]string{
+					"argocd.argoproj.io/sync-options": "Replace=true",
+				},
+			},
+			Spec: monitoringv1.ServiceMonitorSpec{
+				Endpoints: []monitoringv1.Endpoint{
+					{
+						BearerTokenFile:      "/var/run/secrets/kubernetes.io/serviceaccount/token",
+						Interval:             "60s",
+						Port:                 "metrics",
+						MetricRelabelConfigs: common.DropMetricsRelabeling(cfg),
+					},
+					{
+						BearerTokenFile:      "/var/run/secrets/kubernetes.io/serviceaccount/token",
+						Interval:             "60s",
+						Port:                 "metrics",
+						Path:                 "/api-metrics",
+						MetricRelabelConfigs: common.DropMetricsRelabeling(cfg),
+					},
+				},
+				JobLabel: "app.kubernetes.io/component",
+				NamespaceSelector: monitoringv1.NamespaceSelector{
+					MatchNames: []string{GitpodNamespace},
+				},
+				Selector: metav1.LabelSelector{
+					MatchLabels: labels(target),
+				},
+			},
+		})
+
+		return res, nil
+	}
+}

--- a/installer/pkg/components/gitpod/objects.go
+++ b/installer/pkg/components/gitpod/objects.go
@@ -31,6 +31,7 @@ func Objects(ctx *common.RenderContext) common.RenderFunc {
 		workspaceObjects(),
 		proxyCaddyObjects(),
 		messagebusObjects(),
+		ideMetricsObjects(),
 	)
 
 	return common.CompositeRenderFunc(objects...)


### PR DESCRIPTION
IDE-metrics is a service that can let ide components such as supervisor/vscode submit there metrics into it, and we can use this service to uniform collection of metrics for these short-lived services

But we did not collect any metrics data from ide-metrics itself before, i.e. we don't know the success rate and latency of the api calls of reportError or addCounter

This PR add this support, metrics for ide-metrics itself using `/api-metrics` endpoint and the other one use `/metrics` endpoint
