### PR TITLE
Migrate k8s resources

### DIFF
--- a/addons/grafana-on-gcp-oauth.libsonnet
+++ b/addons/grafana-on-gcp-oauth.libsonnet
@@ -47,7 +47,7 @@ function(config) {
     },
 
     ingress: {
-      apiVersion: 'extensions/v1beta1',
+      apiVersion: 'networking.k8s.io/v1',
       kind: 'Ingress',
       metadata: {
         annotations: {
@@ -66,10 +66,15 @@ function(config) {
           http: {
             paths: [{
               backend: {
-                serviceName: $.grafana.service.metadata.name,  // same name put on service resource
-                servicePort: 3000,
+                service: {
+                  name: $.grafana.service.metadata.name,  // same name put on service resource
+                  port: {
+                    number: 3000,
+                  },
+                },
               },
               path: '/*',
+              pathType: 'ImplementationSpecific',
             }],
           },
 

--- a/addons/pyrra-ingress.libsonnet
+++ b/addons/pyrra-ingress.libsonnet
@@ -72,7 +72,7 @@ function(config) {
                   port: {
                     number: 9099,
                   },
-                }
+                },
               },
               path: '/*',
               pathType: 'ImplementationSpecific',

--- a/addons/pyrra-ingress.libsonnet
+++ b/addons/pyrra-ingress.libsonnet
@@ -48,7 +48,7 @@ function(config) {
     },
 
     ingress: {
-      apiVersion: 'extensions/v1beta1',
+      apiVersion: 'networking.k8s.io/v1',
       kind: 'Ingress',
       metadata: {
         annotations: {
@@ -67,10 +67,15 @@ function(config) {
           http: {
             paths: [{
               backend: {
-                serviceName: $.pyrra.apiService.metadata.name,
-                servicePort: 9099,
+                service: {
+                  name: $.pyrra.apiService.metadata.name,
+                  port: {
+                    number: 9099,
+                  },
+                }
               },
               path: '/*',
+              pathType: 'ImplementationSpecific',
             }],
           },
 

--- a/components/victoriametrics/victoriametrics.libsonnet
+++ b/components/victoriametrics/victoriametrics.libsonnet
@@ -293,7 +293,7 @@ function(params) {
                 port: {
                   number: $._config.vmAuthPort,
                 },
-              }
+              },
             },
             path: '/*',
             pathType: 'ImplementationSpecific',

--- a/components/victoriametrics/victoriametrics.libsonnet
+++ b/components/victoriametrics/victoriametrics.libsonnet
@@ -32,7 +32,7 @@ function(params) {
   assert std.objectHas(config.victoriametrics, 'memory') : 'victoriametrics.memory is required',
 
   clusterRole: {
-    apiVersion: 'rbac.authorization.k8s.io/v1beta1',
+    apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRole',
     metadata: {
       labels: $._config.commonLabels,
@@ -47,7 +47,7 @@ function(params) {
   },
 
   clusterRoleBinding: {
-    apiVersion: 'rbac.authorization.k8s.io/v1beta1',
+    apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleBinding',
     metadata: {
       labels: $._config.commonLabels,
@@ -269,7 +269,7 @@ function(params) {
   },
 
   vmAuthIngress: {
-    apiVersion: 'extensions/v1beta1',
+    apiVersion: 'networking.k8s.io/v1',
     kind: 'Ingress',
     metadata: {
       annotations: {
@@ -288,10 +288,15 @@ function(params) {
         http: {
           paths: [{
             backend: {
-              serviceName: $.serviceVmAuth.metadata.name,  // same name put on service resource
-              servicePort: $._config.vmAuthPort,
+              service: {
+                name: $.serviceVmAuth.metadata.name,  // same name put on service resource
+                port: {
+                  number: $._config.vmAuthPort,
+                },
+              }
             },
             path: '/*',
+            pathType: 'ImplementationSpecific',
           }],
         },
       }],


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Resources are out-to-dated, it leads observability auto deployment failed, migration see https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122

[argoCD](https://argo-cd.gitpod-io-dev.com/applications/gitpod-monitor-europe-west1-01-monitoring-central?resource=sync%3AOutOfSync&conditions=false&operation=true)
<img width="1385" alt="image" src="https://github.com/gitpod-io/observability/assets/20944364/68531a81-2ccf-4492-97a2-70e41efa7444">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [internal chat](https://gitpod.slack.com/archives/C032A46PWR0/p1696926861232429)

## How to test
<!-- Provide steps to test this PR -->